### PR TITLE
fix: buttons not working in group dms

### DIFF
--- a/src/structures/Extenders.ts
+++ b/src/structures/Extenders.ts
@@ -1,4 +1,4 @@
-import { BaseInteraction, Message } from "discord.js";
+import { BaseInteraction, DMMessageManager, Message, PartialGroupDMChannel } from "discord.js";
 import { getTranslator } from "#src/i18n";
 import { getSettings, getUser } from "#src/database/index";
 /* prettier-ignore */
@@ -20,3 +20,15 @@ Message.prototype.t = async function() {
   const uSettings = await getUser(user);
   return getTranslator(uSettings.language?.value || gSettings?.language?.value || "en-US");
 };
+
+// TODO: Remove this when djs fixes this issue
+Object.defineProperty(PartialGroupDMChannel, "messages", {
+  // prettier-ignore
+  get: function() {
+    if (!this._messages) {
+      // @ts-ignore
+      this._messages = new DMMessageManager(this);
+    }
+    return this._messages;
+  },
+});


### PR DESCRIPTION
fixes #40 

this is not exactly a fix but a workaround. The real fix is complicated, and I will wait for discord.js to support user apps (where this issue will be addressed).

we use the good ol' `defineProperty` to define a `messages` property for `PartialGroupDMChannel`, so it'll consider it as a text channel. I'll remove this once djs releases the user app support
```ts
Object.defineProperty(PartialGroupDMChannel, "messages", {
  // prettier-ignore
  get: function() {
    if (!this._messages) {
      // @ts-ignore
      this._messages = new DMMessageManager(this);
    }
    return this._messages;
  },
});
```