### PR TITLE
Feat/auth-check

### DIFF
--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -9,6 +9,7 @@ import { AuthMiddleware } from "./middlewares/auth.middleware.js";
 import { StatsController } from "./controllers/stats.controller.js";
 import { UpdateController } from "./controllers/update.controller.js";
 import { UsersController } from "./controllers/user.controller.js";
+import { GuildMiddleware } from "./middlewares/guild.middleware.js";
 export async function Dashboard(client: SkyHelper) {
   @Module({
     imports: [],
@@ -18,6 +19,7 @@ export async function Dashboard(client: SkyHelper) {
   class AppModule implements NestModule {
     configure(consumer: MiddlewareConsumer) {
       consumer.apply(AuthMiddleware).forRoutes("guilds", "update");
+      consumer.apply(GuildMiddleware).forRoutes("guilds");
     }
   }
 

--- a/src/api/managers/LiveShard.ts
+++ b/src/api/managers/LiveShard.ts
@@ -38,18 +38,24 @@ export class LiveShard {
         }
       }
     }
-    const channel = client.channels.cache.get(body.channel)! as TextChannel;
-    const wb2 = await channel.createWebhook({
-      name: "SkyHelper",
-      reason: "For Live SHards",
-    });
-    const m = await wb2.send({ username: "SkyHelper", avatarURL: client.user.displayAvatarURL(), ...response });
-    data.autoShard.messageId = m.id;
-    data.autoShard.active = true;
-    data.autoShard.webhook.id = wb2.id;
-    data.autoShard.webhook.token = wb2.token;
+    let channel,
+      wb2 = null;
+    if (body.channel) {
+      channel = client.channels.cache.get(body.channel)! as TextChannel;
+      wb2 = await channel.createWebhook({
+        name: "SkyHelper",
+        reason: "For Live Skytimes",
+      });
+    }
+    const m = await wb2?.send({ username: "SkyHelper", avatarURL: client.user.displayAvatarURL(), ...response });
+    data.autoTimes.messageId = m?.id || "";
+    data.autoTimes.active = wb2 ? true : false;
+    data.autoTimes.webhook = {
+      id: wb2?.id || null,
+      token: wb2?.token || null,
+    };
     await data.save();
-    return { channel: wb2.channelId };
+    return { channel: wb2?.channelId };
   }
   static async post(client: BotService, guildId: string) {
     const data = await getSettings(client, guildId);

--- a/src/api/managers/LiveTimes.ts
+++ b/src/api/managers/LiveTimes.ts
@@ -37,18 +37,24 @@ export class LiveTimes {
         }
       }
     }
-    const channel = client.channels.cache.get(body.channel)! as TextChannel;
-    const wb2 = await channel.createWebhook({
-      name: "SkyHelper",
-      reason: "For Live Skytimes",
-    });
-    const m = await wb2.send({ username: "SkyHelper", avatarURL: client.user.displayAvatarURL(), ...response });
-    data.autoTimes.messageId = m.id;
-    data.autoTimes.active = true;
-    data.autoTimes.webhook.id = wb2.id;
-    data.autoTimes.webhook.token = wb2.token;
+    let channel,
+      wb2 = null;
+    if (body.channel) {
+      channel = client.channels.cache.get(body.channel)! as TextChannel;
+      wb2 = await channel.createWebhook({
+        name: "SkyHelper",
+        reason: "For Live Skytimes",
+      });
+    }
+    const m = await wb2?.send({ username: "SkyHelper", avatarURL: client.user.displayAvatarURL(), ...response });
+    data.autoTimes.messageId = m?.id || "";
+    data.autoTimes.active = wb2 ? true : false;
+    data.autoTimes.webhook = {
+      id: wb2?.id || null,
+      token: wb2?.token || null,
+    };
     await data.save();
-    return { channel: wb2.channelId };
+    return { channel: wb2?.channelId };
   }
   static async post(client: BotService, guildId: string) {
     const data = await getSettings(client, guildId);

--- a/src/api/middlewares/guild.middleware.ts
+++ b/src/api/middlewares/guild.middleware.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable, type NestMiddleware } from "@nestjs/common";
+import { type UserSession } from "../utils/discord.js";
+import type { Request, Response, NextFunction } from "express";
+import { SkyHelper } from "#bot/structures/SkyHelper";
+
+export interface AuthRequest extends Request {
+  session: UserSession;
+}
+
+@Injectable()
+export class GuildMiddleware implements NestMiddleware {
+  constructor(@Inject("BotClient") private readonly bot: SkyHelper) {}
+
+  async use(req: AuthRequest, _: Response, next: NextFunction) {
+    const guildId = req.url.split("/")[1];
+    await this.bot.checkPermissions(req.session, guildId);
+
+    next();
+  }
+}

--- a/src/bot/structures/SkyHelper.ts
+++ b/src/bot/structures/SkyHelper.ts
@@ -382,13 +382,13 @@ export class SkyHelper extends Client<true> {
    */
   public async checkPermissions(user: UserSession, guildID: string) {
     const guild = this.guilds.cache.get(guildID);
-    if (guild == null) throw new HttpException("Guild Not found", HttpStatus.NOT_FOUND);
+    if (!guild) throw new HttpException("Guild Not found", HttpStatus.NOT_FOUND);
 
     const userID = await getUserID(user.access_token);
-    const member = await guild?.members.fetch(userID);
+    const member = await guild?.members.fetch(userID).catch(() => null);
 
-    if (!member?.permissions.has("Administrator") && guild.ownerId !== member.id) {
-      throw new HttpException("Missing permissions", HttpStatus.BAD_REQUEST);
+    if (!member?.permissions.has("ManageGuild") && guild.ownerId !== member?.id) {
+      throw new HttpException("Missing permissions", HttpStatus.UNAUTHORIZED);
     }
   }
   /**


### PR DESCRIPTION
Users were able to access guild settings even if they were not a member of the said guild or had manage permissions. This pr add a middleware to guilds routes that check for user permissions for the guild and throws exception if they are not authorized