### PR TITLE
chore: re-add allowing setting guild prefix

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -23,8 +23,13 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.4.0
+
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-locfile
 
       - name: Build the project
-        run: npm run build:ci
+        run: pnpm build:ci

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -29,7 +29,7 @@ jobs:
           version: 9.4.0
 
       - name: Install dependencies
-        run: pnpm install --frozen-locfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build the project
         run: pnpm build:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -18,9 +18,13 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.4.0
+
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: npm test
-
+        run: pnpm test

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -29,6 +29,7 @@
       "EMBED_TITLE": "ERROR",
       "MESSAGE_BOT_NO_PERM": "Hi, It seems you tried to use my command in a channel/server where I don't have {{PERMISSIONS}}. Please ask a server admin to grant me necessary permissions before trying to use my commands.\n\nFrom :-\n- Server: {{SERVER}}\n- Channel: {{CHANNEL}}\n- Command Used: `{{COMMAND}}`",
       "MESSAGE_NO_ARGS": "You didn't provide any arguments\n\n**Available Args**: {{ARGS}}!",
+      "MINIMUM_ARGS": "You need to provide minimum `{{LIMIT}}` args for this command",
       "INVALID_ARGS": "Invalid Arguments!",
       "NO_PERMS_USER": "You don't have necessary permission(s) ({{PERMISSIONS}}) to use this command.",
       "NOT_A_SERVER": "Oops! Looks like you ran this command in a server where I'm not in or as an User App command. This command is only meant to be used in a server I am a member of.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         specifier: ^1.0.9
         version: 1.0.9
       discord.js:
-        specifier: ^14.15.3
+        specifier: 14.15.3
         version: 14.15.3
       dotenv:
         specifier: ^16.3.1
@@ -4178,7 +4178,7 @@ snapshots:
       discord-api-types: 0.37.83
       fast-deep-equal: 3.1.3
       ts-mixer: 6.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   "@discordjs/collection@1.5.3": {}
 
@@ -4212,7 +4212,7 @@ snapshots:
       "@vladfrangu/async_event_emitter": 2.2.4
       discord-api-types: 0.37.83
       magic-bytes.js: 1.10.0
-      tslib: 2.6.2
+      tslib: 2.6.3
       undici: 6.13.0
 
   "@discordjs/util@1.1.0": {}
@@ -4226,7 +4226,7 @@ snapshots:
       "@types/ws": 8.5.10
       "@vladfrangu/async_event_emitter": 2.2.4
       discord-api-types: 0.37.83
-      tslib: 2.6.2
+      tslib: 2.6.3
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil

--- a/src/bot/commands/prefix/setprefix.ts
+++ b/src/bot/commands/prefix/setprefix.ts
@@ -1,0 +1,22 @@
+import { PrefixCommand } from "#bot/structures/PrefixCommands";
+
+export default {
+  data: {
+    name: "setprefix",
+    description: "set the prefix for this server",
+    aliases: ["sp"],
+    args: {
+      minimum: 1,
+    },
+    userPermissions: ["ManageGuild"],
+  },
+  async execute({ message: msg, args, client }) {
+    if (!msg.inGuild()) return;
+    const settings = await client.database.getSettings(msg.guild);
+    const prefix = args[0];
+    if (!prefix) return void (await msg.reply("You need to provide a prefix to set!"));
+    settings.prefix = prefix;
+    await settings.save();
+    await msg.reply(`Prefix set to \`${prefix}\` for this server`);
+  },
+} satisfies PrefixCommand;

--- a/src/bot/structures/PrefixCommands.ts
+++ b/src/bot/structures/PrefixCommands.ts
@@ -19,7 +19,7 @@ export interface Validation {
   callback(msg: Message): boolean;
 }
 
-export interface Arg {
+export interface PrefixSubcommand {
   trigger: string;
   description: string;
 }
@@ -37,7 +37,10 @@ export type PrefixCommand = {
     /** Args of the command */
     args?: {
       required?: boolean;
-      args: Arg[];
+      /**Mininum args require */
+      minimum?: number;
+
+      subcommand?: PrefixSubcommand[];
     };
 
     /** Flags for the command */


### PR DESCRIPTION
Mainly for me, and partly for future proofing.

Some prefix commands are already available to general users like (hug), with #47 more commands may be too, so it'll be nice to have it﻿
