### PR TITLE
chore(ci): do no publish packages to npm

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "23"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -75,12 +74,6 @@ jobs:
           pr_url=$(gh pr create --base main --head release/${{ github.event.inputs.package }}-${new_version} --title "chore: release ${{ github.event.inputs.package }} v${new_version}" --body "Automated version bump for ${{ github.event.inputs.package }} v${new_version}")
           pr_number=$(echo $pr_url | grep -o -E '[0-9]+$')
           echo "pr_number=${pr_number}" >> $GITHUB_ENV
-
-      - name: Publish
-        if: contains(fromJSON('["@skyhelperbot/utils", "@skyhelperbot/constants"]'), github.event.inputs.package)
-        run: pnpm --filter '${{ github.event.inputs.package }}' publish --provenance --no-git-checks --access public --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create release
         id: process-prs


### PR DESCRIPTION
Packages are utilized leveraging pnpm workplace, and it is counter productive to to publish it to npm, where there may not be any other users
