### PR TITLE
fix(SkyGame): erroring when used in threads

### DIFF
--- a/packages/skyhelper/src/bot/modules/inputCommands/fun/skygame.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/fun/skygame.ts
@@ -108,10 +108,7 @@ async function skygamePrecheck(helper: InteractionHelper, options: InteractionOp
   }
 
   // check bot has necessary perms in the channel
-  const channel = guild && client.channels.get(helper.int.channel!.id);
-  const botPermsInChannel = guild
-    ? PermissionsUtil.overwriteFor(guild.clientMember, channel as APITextChannel, client)
-    : undefined;
+  const botPermsInChannel = new PermissionsUtil(helper.int.app_permissions as `${number}`);
   if (!scrambleSingleModePreCheck && guild && !botPermsInChannel?.has(["SendMessages", "ViewChannel"])) {
     await helper.reply({
       content: t("errors:NO_PERMS_BOT", {


### PR DESCRIPTION
I do not cache threads so consiquently, channel was getting undefined when recieving from cache for the pre check when the command was used in a thread.
Instead, using app_permissions return in interaction payload, which includes the relevant information already (dont know why i wasnt using it already).
It saves from having to do additional things by me.
