### PR TITLE
refactor: remove mapped spirit icons in spirit list

### DIFF
--- a/packages/skyhelper/src/bot/modules/inputCommands/info/spirits.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/info/spirits.ts
@@ -71,13 +71,7 @@ async function handleSpiritList(helper: InteractionHelper) {
         ...data.flatMap(([key, spirit]) => {
           const seasonIcon = "ts" in spirit ? season_emojis[spirit.season] : "";
           const realmIcon = spirit.realm ? realms_emojis[spirit.realm] : "";
-          let icon = appMojis.filter((e) => e.name.split("_").slice(0, -1).join("_") === key.replaceAll("-", ""));
-          if (icon.length === 0) {
-            icon = appMojis.filter((e) => e.name.startsWith("ts"));
-          }
-          const mapped = icon
-            .sort((a, b) => Number(a.name.split("_").at(-1)) - Number(b.name.split("_").at(-1)))
-            .map((e) => `<${e.animated ? "a" : ""}:${e.name}:${e.id}>`);
+
           return [
             section(
               {
@@ -86,8 +80,8 @@ async function handleSpiritList(helper: InteractionHelper) {
                 custom_id: store.serialize(CustomId.SpiritButton, { spirit_key: key, user: null }),
                 style: 2,
               },
-              `${mapped[0]}${mapped[1]} **${spirit.name}${spirit.extra ? ` (${spirit.extra})` : ""} [↗](https://sky-children-of-the-light.fandom.com/wiki/${spirit.name.split(" ").join("_")})**`,
-              `${mapped[2]}${mapped[3]}${realmIcon}${seasonIcon}${spirit.collectibles?.map((c) => c.icon).join(" ") ?? ""}`,
+              `$**${spirit.name}${spirit.extra ? ` (${spirit.extra})` : ""} [↗](https://sky-children-of-the-light.fandom.com/wiki/${spirit.name.split(" ").join("_")})**`,
+              `$${realmIcon}${seasonIcon}${spirit.collectibles?.map((c) => c.icon).join(" ") ?? ""}`,
             ),
           ];
         }),

--- a/packages/skyhelper/src/bot/modules/inputCommands/info/spirits.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/info/spirits.ts
@@ -80,8 +80,8 @@ async function handleSpiritList(helper: InteractionHelper) {
                 custom_id: store.serialize(CustomId.SpiritButton, { spirit_key: key, user: null }),
                 style: 2,
               },
-              `$**${spirit.name}${spirit.extra ? ` (${spirit.extra})` : ""} [↗](https://sky-children-of-the-light.fandom.com/wiki/${spirit.name.split(" ").join("_")})**`,
-              `$${realmIcon}${seasonIcon}${spirit.collectibles?.map((c) => c.icon).join(" ") ?? ""}`,
+              `**${spirit.name}${spirit.extra ? ` (${spirit.extra})` : ""} [↗](https://sky-children-of-the-light.fandom.com/wiki/${spirit.name.split(" ").join("_")})**`,
+              `${realmIcon}${seasonIcon}${spirit.collectibles?.map((c) => c.icon).join(" ") ?? ""}`,
             ),
           ];
         }),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove mapped spirit icon logic from spirit list display

- Simplify spirit list rendering by removing icon filtering

- Clean up emoji mapping and sorting functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Spirit List Handler"] --> B["Icon Mapping Logic"]
  B --> C["Filtered & Sorted Icons"]
  C --> D["Display Format"]
  A --> E["Simplified Display"]
  E --> F["Direct Spirit Info"]
  B -.-> |"Removed"| G["Complex Icon Processing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spirits.ts</strong><dd><code>Remove spirit icon mapping logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/skyhelper/src/bot/modules/inputCommands/info/spirits.ts

<ul><li>Removed <code>appMojis</code> filtering logic for spirit icons<br> <li> Eliminated icon sorting and mapping functionality<br> <li> Simplified spirit display format by removing mapped icons<br> <li> Kept realm and season icons while removing complex spirit-specific <br>icons</ul>


</details>


  </td>
  <td><a href="https://github.com/imnaiyar/SkyHelper/pull/332/files#diff-15fa7838a4bcdcd674e8fa27d684c605b501903b310e0c8c648bef822c6fd6b3">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

