### PR TITLE
fix(Planner): set start and end date accurately

### DIFF
--- a/packages/constants/src/skygame-planner/service.ts
+++ b/packages/constants/src/skygame-planner/service.ts
@@ -206,9 +206,9 @@ export function getWingedLightsInRealm(realmId: string, data: PlannerAssetData) 
 export function getCurrentTravelingSpirit(data: PlannerAssetData) {
   const now = DateTime.now().setZone(zone);
   return data.travelingSpirits.find((ts) => {
-    const startDate = resolveToLuxon(ts.date);
+    const startDate = resolveToLuxon(ts.date).startOf("day");
     const endDate = !ts.endDate ? startDate.plus({ day: 3 }) : resolveToLuxon(ts.endDate);
-    return now >= startDate && now <= endDate;
+    return now >= startDate && now <= endDate.endOf("day");
   });
 }
 
@@ -265,8 +265,8 @@ export function getEvents(data: PlannerAssetData) {
 
   for (const event of data.events) {
     for (const instance of event.instances ?? []) {
-      const startDate = resolveToLuxon(instance.date);
-      const endDate = resolveToLuxon(instance.endDate);
+      const startDate = resolveToLuxon(instance.date).startOf("day");
+      const endDate = resolveToLuxon(instance.endDate).endOf("day");
 
       if (now >= startDate && now <= endDate) {
         currentEvents.push({
@@ -300,8 +300,8 @@ export function getEvents(data: PlannerAssetData) {
 export function getCurrentSeason(data: PlannerAssetData) {
   const now = DateTime.now().setZone(zone);
   return data.seasons.find((season) => {
-    const startDate = resolveToLuxon(season.date);
-    const endDate = resolveToLuxon(season.endDate);
+    const startDate = resolveToLuxon(season.date).startOf("day");
+    const endDate = resolveToLuxon(season.endDate).endOf("day");
     return now >= startDate && now <= endDate;
   });
 }
@@ -314,8 +314,8 @@ export function getCurrentSeason(data: PlannerAssetData) {
 export function getCurrentReturningSpirits(data: PlannerAssetData) {
   const now = DateTime.now().setZone(zone);
   return data.returningSpirits.filter((visit) => {
-    const startDate = resolveToLuxon(visit.date);
-    const endDate = resolveToLuxon(visit.endDate);
+    const startDate = resolveToLuxon(visit.date).startOf("day");
+    const endDate = resolveToLuxon(visit.endDate).endOf("day");
     return now >= startDate && now <= endDate;
   });
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix date range calculations for traveling spirits, events, seasons, and returning spirits

- Normalize start dates to beginning of day and end dates to end of day

- Ensure accurate time-based filtering for active game content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Date Resolution"] --> B["Start of Day"]
  A --> C["End of Day"]
  B --> D["Accurate Range Check"]
  C --> D
  D --> E["Current Content Detection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.ts</strong><dd><code>Normalize date boundaries for accurate range checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/constants/src/skygame-planner/service.ts

<ul><li>Normalize start dates to beginning of day using <code>startOf("day")</code><br> <li> Normalize end dates to end of day using <code>endOf("day")</code><br> <li> Apply fixes to traveling spirits, events, seasons, and returning <br>spirits functions<br> <li> Ensure consistent date range boundary handling across all time-based <br>queries</ul>


</details>


  </td>
  <td><a href="https://github.com/imnaiyar/SkyHelper/pull/338/files#diff-873a0116cda08d7cdfab7cfbf0bb068c6724d0c1b84cff37e0d6c55a0a49124c">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

