### PR TITLE
fix(ItemsDisplay): fallback to random customid since you cant have empty id

### DIFF
--- a/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
+++ b/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
@@ -130,7 +130,7 @@ export class ItemsDisplay extends BasePlannerHandler {
   itemDisplay(item: IItem) {
     return [
       section(
-        this.state.b ? this.backbtn(this.createCustomId({ it: null, f: null, ...this.state.b })) : this.homebtn() // fallback to item home,
+        this.state.b ? this.backbtn(this.createCustomId({ it: null, f: null, ...this.state.b })) : this.homebtn(), // fallback to item home
         `# ${this.formatemoji(item.emoji, item.name)} ${item.name}${item.level ? ` (Lvl ${item.level})` : ""}`,
         [`Type: ${item.type}`, item.subtype ? `Subtype: ${item.subtype}` : null, item.group ? `Group: ${item.group}` : null]
           .filter(Boolean)

--- a/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
+++ b/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
@@ -146,7 +146,7 @@ export class ItemsDisplay extends BasePlannerHandler {
       row(
         (() => {
           const sourceNav = this.getItemSourceNavigation(item);
-          return this.viewbtn(sourceNav ?? Math.floor(Math.random() * 1000).toString(), {
+          return this.viewbtn(sourceNav || "disabled-find-source", {
             label: "Find Source",
             disabled: !sourceNav,
           });

--- a/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
+++ b/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
@@ -130,7 +130,7 @@ export class ItemsDisplay extends BasePlannerHandler {
   itemDisplay(item: IItem) {
     return [
       section(
-        ...(this.state.b ? [this.backbtn(this.createCustomId({ it: null, f: null, ...this.state.b }))] : []),
+        this.state.b ? this.backbtn(this.createCustomId({ it: null, f: null, ...this.state.b })) : this.homebtn() // fallback to item home,
         `# ${this.formatemoji(item.emoji, item.name)} ${item.name}${item.level ? ` (Lvl ${item.level})` : ""}`,
         [`Type: ${item.type}`, item.subtype ? `Subtype: ${item.subtype}` : null, item.group ? `Group: ${item.group}` : null]
           .filter(Boolean)

--- a/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
+++ b/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
@@ -130,9 +130,7 @@ export class ItemsDisplay extends BasePlannerHandler {
   itemDisplay(item: IItem) {
     return [
       section(
-        ...(this.state.b
-          ? [this.backbtn(this.createCustomId({ t: DisplayTabs.Items, it: null, f: null, ...this.state.b }))]
-          : []),
+        ...(this.state.b ? [this.backbtn(this.createCustomId({ it: null, f: null, ...this.state.b }))] : []),
         `# ${this.formatemoji(item.emoji, item.name)} ${item.name}${item.level ? ` (Lvl ${item.level})` : ""}`,
         [`Type: ${item.type}`, item.subtype ? `Subtype: ${item.subtype}` : null, item.group ? `Group: ${item.group}` : null]
           .filter(Boolean)

--- a/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
+++ b/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
@@ -130,7 +130,9 @@ export class ItemsDisplay extends BasePlannerHandler {
   itemDisplay(item: IItem) {
     return [
       section(
-        this.backbtn(this.createCustomId({ t: DisplayTabs.Items, it: null, f: null, ...this.state.b })),
+        ...(this.state.b
+          ? [this.backbtn(this.createCustomId({ t: DisplayTabs.Items, it: null, f: null, ...this.state.b }))]
+          : []),
         `# ${this.formatemoji(item.emoji, item.name)} ${item.name}${item.level ? ` (Lvl ${item.level})` : ""}`,
         [`Type: ${item.type}`, item.subtype ? `Subtype: ${item.subtype}` : null, item.group ? `Group: ${item.group}` : null]
           .filter(Boolean)
@@ -146,7 +148,10 @@ export class ItemsDisplay extends BasePlannerHandler {
       row(
         (() => {
           const sourceNav = this.getItemSourceNavigation(item);
-          return this.viewbtn(sourceNav ?? "", { label: "Find Source", disabled: !sourceNav });
+          return this.viewbtn(sourceNav ?? Math.floor(Math.random() * 1000).toString(), {
+            label: "Find Source",
+            disabled: !sourceNav,
+          });
         })(),
         button({
           custom_id: this.createCustomId({}),

--- a/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
+++ b/packages/skyhelper/src/bot/handlers/planner-displays/items.ts
@@ -146,6 +146,7 @@ export class ItemsDisplay extends BasePlannerHandler {
       row(
         (() => {
           const sourceNav = this.getItemSourceNavigation(item);
+          // eslint-disable-next-line
           return this.viewbtn(sourceNav || "disabled-find-source", {
             label: "Find Source",
             disabled: !sourceNav,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix empty custom ID issue in ItemsDisplay component

- Add conditional back button rendering based on state

- Implement random fallback for source navigation button


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ItemsDisplay"] --> B["Back Button"]
  A --> C["Source Navigation"]
  B --> D["Conditional Rendering"]
  C --> E["Random Fallback ID"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>items.ts</strong><dd><code>Fix conditional rendering and empty ID handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/skyhelper/src/bot/handlers/planner-displays/items.ts

<ul><li>Add conditional rendering for back button based on <code>this.state.b</code><br> <li> Replace empty custom ID with random number fallback for source <br>navigation<br> <li> Prevent UI errors from empty button identifiers</ul>


</details>


  </td>
  <td><a href="https://github.com/imnaiyar/SkyHelper/pull/339/files#diff-1881fa8af7445c80ec52a63071501e3730cab54ea12106b8692e8cb9e99734e1">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

