### PR TITLE
feat(shards-calendar): show generated month calendar for the shard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/test.mjs
 **/test.ts
 **/deployed
+AGENTS.md
 
 # Turborepo
 .turbo

--- a/packages/constants/locales/en-US/commands.json
+++ b/packages/constants/locales/en-US/commands.json
@@ -106,6 +106,10 @@
       "EMBED_DESCRIPTION": "For detailed shard info, use {{shardsCmd}}",
       "EMBED_FOOTER": "Page {{INDEX}}/{{TOTAL}}",
       "CHANGE_BUTTON": "Change Month/Year",
+      "SELECT_INFOGRAPHICS": "Infographics",
+      "SELECT_INFOGRAPHICS_DESCRIPTION": "Show shard calendar as an infographic in a real calendar style",
+      "SELECT_LEGACY": "Legacy",
+      "SELECT_LEGACY_DESCRIPTION": "Legacy way of viewing the calendar where it was displayed as texts",
       "MODAL_MONTH": "Select Month",
       "MODAL_YEAR": "Enter Year (Format: YYYY)",
       "INVALID_DATE": "Invalid date format (`{{DATE}}`). Please enter the month and year in this format: MM-YYYY (e.g. 01-2022)"

--- a/packages/constants/locales/en-US/commands.json
+++ b/packages/constants/locales/en-US/commands.json
@@ -107,9 +107,9 @@
       "EMBED_FOOTER": "Page {{INDEX}}/{{TOTAL}}",
       "CHANGE_BUTTON": "Change Month/Year",
       "SELECT_INFOGRAPHICS": "Infographics",
-      "SELECT_INFOGRAPHICS_DESCRIPTION": "Show shard calendar as an infographic in a real calendar style",
+      "SELECT_INFOGRAPHICS_DESCRIPTION": "Show the shard calendar as a calendar-style infographic",
       "SELECT_LEGACY": "Legacy",
-      "SELECT_LEGACY_DESCRIPTION": "Legacy way of viewing the calendar where it was displayed as texts",
+      "SELECT_LEGACY_DESCRIPTION": "Show the shard calendar in the legacy text-only view",
       "MODAL_MONTH": "Select Month",
       "MODAL_YEAR": "Enter Year (Format: YYYY)",
       "INVALID_DATE": "Invalid date format (`{{DATE}}`). Please enter the month and year in this format: MM-YYYY (e.g. 01-2022)"

--- a/packages/jobs/src/functions/getResponses.ts
+++ b/packages/jobs/src/functions/getResponses.ts
@@ -1,5 +1,5 @@
 import { emojis, type REMINDERS_KEY } from "@skyhelperbot/constants";
-import type { getTranslator, LangKeys, TranslatorType } from "./getTranslator";
+import type { LangKeys, TranslatorType } from "./getTranslator";
 import { container, section, separator, ShardsUtil, textDisplay, thumbnail, type EventDetails } from "@skyhelperbot/utils";
 import { MessageFlags } from "discord-api-types/v10";
 import type { DateTime } from "luxon";

--- a/packages/jobs/src/functions/getResponses.ts
+++ b/packages/jobs/src/functions/getResponses.ts
@@ -1,5 +1,5 @@
 import { emojis, type REMINDERS_KEY } from "@skyhelperbot/constants";
-import type { getTranslator, LangKeys } from "./getTranslator";
+import type { getTranslator, LangKeys, TranslatorType } from "./getTranslator";
 import { container, section, separator, ShardsUtil, textDisplay, thumbnail, type EventDetails } from "@skyhelperbot/utils";
 import { MessageFlags } from "discord-api-types/v10";
 import type { DateTime } from "luxon";
@@ -109,12 +109,7 @@ export const getTSResponse = (
   return { components: [component], flags: MessageFlags.IsComponentsV2 };
 };
 
-export function getShardReminderResponse(
-  now: DateTime,
-  t: ReturnType<typeof getTranslator>,
-  offset = 0,
-  shardType?: Array<"red" | "black">,
-) {
+export function getShardReminderResponse(now: DateTime, t: TranslatorType, offset = 0, shardType?: Array<"red" | "black">) {
   const nextShard = ShardsUtil.getNextShard(now, shardType);
   if (!nextShard) return null;
 

--- a/packages/jobs/src/functions/getTranslator.ts
+++ b/packages/jobs/src/functions/getTranslator.ts
@@ -46,3 +46,5 @@ export const getTranslator =
   (lang: string) =>
   (key: LangKeys, options = {}) =>
     i18next.t(key, { ...options, lng: lang });
+
+export type TranslatorType = ReturnType<typeof getTranslator>;

--- a/packages/skyhelper/package.json
+++ b/packages/skyhelper/package.json
@@ -60,6 +60,7 @@
     "express": "^4.22.0",
     "i18next": "^24.2.1",
     "i18next-fs-backend": "^2.6.6",
+    "lru-cache": "^11.5.2",
     "luxon": "^3.5.0",
     "mongoose": "^8.22.1",
     "nanoid": "^5.1.6",

--- a/packages/skyhelper/scripts/shards-calendar-preview.ts
+++ b/packages/skyhelper/scripts/shards-calendar-preview.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env tsx
+/**
+ * Shards Calendar Preview Script
+ *
+ * Renders a monthly shard calendar image to a PNG file for previewing, using
+ * the same `@napi-rs/canvas` generator the bot will use.
+ *
+ * Usage:
+ *   pnpm exec scripts/shards-calendar-preview.ts [--month=6] [--year=2026] [--scale=1] [--output=file.png]
+ */
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { generateShardsCalendarCard } from "../src/bot/utils/image-generators/ShardsCalendarCard.js";
+
+interface ScriptOptions {
+  month?: number;
+  year?: number;
+  scale: number;
+  output: string;
+}
+
+/** Parse command line arguments (--key=value only) */
+function parseArgs(): ScriptOptions {
+  const args = process.argv.slice(2);
+  const options: ScriptOptions = { scale: 1, output: "shards-calendar-preview.png" };
+
+  for (const arg of args) {
+    if (arg.startsWith("--month=")) {
+      options.month = Number(arg.slice("--month=".length));
+    } else if (arg.startsWith("--year=")) {
+      options.year = Number(arg.slice("--year=".length));
+    } else if (arg.startsWith("--scale=")) {
+      options.scale = Number(arg.slice("--scale=".length));
+    } else if (arg.startsWith("--output=")) {
+      options.output = arg.slice("--output=".length);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      console.error("Usage: pnpm shards-calendar-preview [--month=6] [--year=2026] [--scale=1] [--output=file.png]");
+      process.exit(1);
+    }
+  }
+
+  if (!Number.isFinite(options.scale) || options.scale <= 0) {
+    console.error(`❌ Invalid scale: ${options.scale} (must be a positive number)`);
+    process.exit(1);
+  }
+
+  return options;
+}
+
+async function main() {
+  try {
+    const options = parseArgs();
+    if (options.month !== undefined && (options.month < 1 || options.month > 12)) {
+      console.error(`❌ Invalid month: ${options.month} (must be 1-12)`);
+      process.exit(1);
+    }
+
+    const dateLabel = options.month && options.year ? `${options.month}/${options.year}` : "current month";
+    console.log(`📅 Rendering shards calendar for ${dateLabel}...`);
+    console.time("Render time");
+
+    const buffer = await generateShardsCalendarCard({
+      month: options.month,
+      year: options.year,
+      scale: options.scale,
+    });
+
+    console.timeEnd("Render time");
+
+    const outputPath = resolve(process.cwd(), options.output);
+    writeFileSync(outputPath, buffer);
+
+    // PNG dimensions live in the IHDR chunk: width @ offset 16, height @ offset 20
+    const width = buffer.readUInt32BE(16);
+    const height = buffer.readUInt32BE(20);
+
+    console.log(`✅ Calendar rendered successfully!`);
+    console.log(`📁 Output saved to: ${outputPath}`);
+    console.log(`📐 Dimensions: ${width}x${height}`);
+    console.log(`📏 File size: ${(buffer.length / 1024).toFixed(1)} KB`);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/packages/skyhelper/src/bot/events/INTERACTION_CREATE.ts
+++ b/packages/skyhelper/src/bot/events/INTERACTION_CREATE.ts
@@ -1,4 +1,4 @@
-import { getTranslator, type TranslatorType } from "@/i18n";
+import { type TranslatorType } from "@/i18n";
 import type { SkyHelper } from "@/structures/Client";
 import type { Command } from "@/structures/Command";
 import type { Event } from "@/structures/Event";

--- a/packages/skyhelper/src/bot/events/INTERACTION_CREATE.ts
+++ b/packages/skyhelper/src/bot/events/INTERACTION_CREATE.ts
@@ -1,4 +1,4 @@
-import { getTranslator } from "@/i18n";
+import { getTranslator, type TranslatorType } from "@/i18n";
 import type { SkyHelper } from "@/structures/Client";
 import type { Command } from "@/structures/Command";
 import type { Event } from "@/structures/Event";
@@ -38,6 +38,7 @@ import type { DisplayTabs, NavigationState } from "@/types/planner";
 import { setLoadingState } from "@/utils/loading";
 import { handleCalculatorModal } from "@/handlers/calculator";
 import { handleSeasonCalculatorButton } from "@/handlers/season-calculator";
+import { buildCalendarResponse } from "@/utils/classes/Embeds";
 const interactionLogWebhook = process.env.COMMANDS_USED ? Utils.parseWebhookURL(process.env.COMMANDS_USED) : null;
 
 const formatCommandOptions = (int: APIChatInputApplicationCommandInteraction, options: InteractionOptionResolver) =>
@@ -260,9 +261,6 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
         case "errorModal":
           await handleErrorModal(helper);
           return;
-        case "shards-calendar-modal-date":
-          await handleShardsCalendarModal(helper);
-          return;
         case "currency_modify":
           await handleCurrencyModifyModal(helper);
           break;
@@ -276,6 +274,11 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
             await handleCalculatorModal(helper);
             return;
           }
+
+          if (id.startsWith("shards-calendar-modal-date")) {
+            await handleShardsCalendarModal(helper);
+            return;
+          }
           return;
         }
       }
@@ -284,6 +287,8 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
     // #region selects
     if (helper.isSelect(interaction)) {
       const { id, data } = client.utils.store.deserialize(interaction.data.custom_id);
+      const values = interaction.data.values;
+
       switch (id) {
         case CustomId.TimesDetailsRow:
           await handleSkyTimesSelect(interaction, helper);
@@ -291,9 +296,9 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
         case CustomId.PlannerTopLevelNav: {
           const getLoading = setLoadingState(interaction.message.components!, interaction.data.custom_id);
           await helper.update({ components: getLoading });
-          const values = interaction.data.values;
           const { t: tab, p, d, f, it, back } = data;
           const b = back ? (client.utils.parseCustomId(back) as unknown as Omit<NavigationState, "back" | "values">) : undefined;
+
           const res = await handlePlannerNavigation(
             {
               v: values,
@@ -308,6 +313,7 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
             helper.user,
             client,
           );
+
           await helper.editReply({
             ...res,
             flags: MessageFlags.IsComponentsV2,
@@ -317,7 +323,7 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
         case CustomId.PlannerSelectNav: {
           const getLoading = setLoadingState(interaction.message.components!, interaction.data.custom_id);
           await helper.update({ components: getLoading });
-          const values = interaction.data.values;
+
           const res = await handlePlannerNavigation(
             {
               t: values[0] as DisplayTabs,
@@ -329,6 +335,20 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
             ...res,
             flags: MessageFlags.IsComponentsV2,
           });
+          return;
+        }
+
+        case CustomId.CalendarToggle: {
+          const { month, year } = data;
+
+          const loadingState = setLoadingState(interaction.message.components!, interaction.data.custom_id);
+
+          await helper.update({ components: loadingState });
+
+          const response = await buildCalendarResponse(helper.t, helper.user.id, { month, year }, values[0] === "legacy");
+
+          await helper.editReply(response);
+
           return;
         }
         default:
@@ -343,7 +363,7 @@ const interactionHandler: Event<GatewayDispatchEvents.InteractionCreate> = async
 export default interactionHandler;
 
 // Ugly codes begin...uggh
-function getErrorResponse(id: string, t: ReturnType<typeof getTranslator>) {
+function getErrorResponse(id: string, t: TranslatorType) {
   return {
     content: t("errors:ERROR_ID", { ID: id }),
     embeds: [{ title: t("errors:EMBED_TITLE"), description: t("errors:EMBED_DESCRIPTION") }],

--- a/packages/skyhelper/src/bot/handlers/modalHandler.ts
+++ b/packages/skyhelper/src/bot/handlers/modalHandler.ts
@@ -2,16 +2,27 @@ import type { SkyHelper } from "@/structures";
 import { buildCalendarResponse } from "@/utils/classes/Embeds";
 import { InteractionHelper } from "@/utils/classes/InteractionUtil";
 import Utils from "@/utils/classes/Utils";
-import { ComponentType, MessageFlags, type APIEmbed, type APIModalSubmitInteraction } from "@discordjs/core";
+import {
+  ComponentType,
+  MessageFlags,
+  type APIButtonComponentWithCustomId,
+  type APIContainerComponent,
+  type APIEmbed,
+  type APIModalSubmitInteraction,
+} from "@discordjs/core";
 import { resolveColor } from "@skyhelperbot/utils";
 import { DateTime } from "luxon";
 import { fetchSkyData, handlePlannerNavigation, PlannerDataService } from "@/planner";
 import { DisplayTabs } from "@/types/planner";
 import { nanoid } from "nanoid";
+import { setLoadingState } from "@/utils/loading";
+import { CustomId, store } from "@/utils/customId-store";
 
 export async function handleShardsCalendarModal(helper: InteractionHelper) {
-  const monthValue = Utils.getModalComponent(helper.int as APIModalSubmitInteraction, "month", ComponentType.StringSelect, true).values[0];
-  const yearValue = Utils.getTextInput(helper.int as APIModalSubmitInteraction, "year", true).value;
+  const int = helper.int as APIModalSubmitInteraction;
+
+  const monthValue = Utils.getModalComponent(int, "month", ComponentType.StringSelect, true).values[0];
+  const yearValue = Utils.getTextInput(int, "year", true).value;
 
   const month = Number(monthValue);
   const year = Number(yearValue);
@@ -37,8 +48,19 @@ export async function handleShardsCalendarModal(helper: InteractionHelper) {
     return;
   }
 
-  const data = buildCalendarResponse(helper.t, helper.client, helper.user.id, { month, year, index: 0 });
-  await helper.update({ ...data, flags: MessageFlags.IsComponentsV2 });
+  const legacy = int.data.custom_id.split(";")[1] === "true";
+
+  const accessory = (int.message?.components?.[0] as APIContainerComponent).components.find(
+    (c) => c.type == ComponentType.Section,
+  )?.accessory;
+
+  const loadingState = setLoadingState(int.message!.components!, (accessory as APIButtonComponentWithCustomId).custom_id);
+
+  await helper.update({ components: loadingState });
+
+  const data = await buildCalendarResponse(helper.t, helper.user.id, { month, year, index: 0 }, legacy);
+
+  await helper.editReply({ ...data, flags: MessageFlags.IsComponentsV2 });
   return;
 }
 

--- a/packages/skyhelper/src/bot/i18n.ts
+++ b/packages/skyhelper/src/bot/i18n.ts
@@ -26,3 +26,5 @@ export const getTranslator =
   (lang: string) =>
   (key: LangKeys, options = {}) =>
     i18next.t(key, { ...options, lng: lang });
+
+export type TranslatorType = ReturnType<typeof getTranslator>;

--- a/packages/skyhelper/src/bot/modules/buttons/calendar-date.ts
+++ b/packages/skyhelper/src/bot/modules/buttons/calendar-date.ts
@@ -7,11 +7,11 @@ export default defineButton({
   data: {
     name: "shards-calendar-date-update",
   },
-  id: CustomId.CalendarDate,
-  async execute(_interaction, _t, helper, { month, year }) {
+  id: CustomId.CalendarToggle,
+  async execute(_interaction, _t, helper, { month, year, legacy = false }) {
     const modal: APIModalInteractionResponseCallbackData = {
       title: "Change Date/Month",
-      custom_id: "shards-calendar-modal-date",
+      custom_id: "shards-calendar-modal-date" + `;${legacy}`,
       components: [
         {
           type: ComponentType.Label,

--- a/packages/skyhelper/src/bot/modules/buttons/calendar-nav.ts
+++ b/packages/skyhelper/src/bot/modules/buttons/calendar-nav.ts
@@ -9,12 +9,21 @@ export default defineButton({
   },
   id: CustomId.CalenderNav,
   async execute(_interaction, t, helper, { index, month, year }) {
-    await helper.update({
-      ...buildCalendarResponse(t, helper.client, helper.user.id, {
+    await helper.deferUpdate();
+
+    const response = await buildCalendarResponse(
+      t,
+      helper.user.id,
+      {
         index: index,
         month: month,
         year: year,
-      }),
+      },
+      true,
+    );
+
+    await helper.editReply({
+      ...response,
       flags: MessageFlags.IsComponentsV2,
     });
   },

--- a/packages/skyhelper/src/bot/modules/buttons/spirits/spirit-expression.ts
+++ b/packages/skyhelper/src/bot/modules/buttons/spirits/spirit-expression.ts
@@ -1,5 +1,5 @@
 import { defineButton } from "@/structures";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import { InteractionHelper } from "@/utils/classes/InteractionUtil";
 import { ButtonStyle, ComponentType, type APIButtonComponent } from "@discordjs/core";
 import Utils from "@/utils/classes/Utils";
@@ -57,7 +57,7 @@ export default defineButton({
   },
 });
 
-const getEmoteResponse = (spirit: ISpirit, t: ReturnType<typeof getTranslator>, user: string) => {
+const getEmoteResponse = (spirit: ISpirit, t: TranslatorType, user: string) => {
   const expressions = SpiritTreeHelper.getItems(spirit.tree, true)
     .filter((item) => [ItemType.Emote, ItemType.Call, ItemType.Stance].includes(item.type))
     .filter((e) => e.previewUrl);

--- a/packages/skyhelper/src/bot/modules/inputCommands/admin/sub/handleLive.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/admin/sub/handleLive.ts
@@ -1,4 +1,4 @@
-import { getTranslator } from "@/i18n";
+import { getTranslator, type TranslatorType } from "@/i18n";
 import type { GuildSchema } from "@/types/schemas";
 import { SkyHelper } from "@/structures";
 import { getTimesEmbed, buildShardEmbed } from "@/utils/classes/Embeds";
@@ -18,7 +18,7 @@ export const handleLive = async (
   type: string,
   sub: string,
   config: GuildSchema,
-  t: ReturnType<typeof getTranslator>,
+  t: TranslatorType,
   resolvedChannel?: APIInteractionDataResolvedChannel,
 ) => {
   const liveType = type === "shards" ? "autoShard" : "autoTimes";

--- a/packages/skyhelper/src/bot/modules/inputCommands/fun/sub/hangman.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/fun/sub/hangman.ts
@@ -24,7 +24,7 @@ import { emojis } from "@skyhelperbot/constants";
 import { container, mediaGallery, mediaGalleryItem, section, separator, textDisplay, thumbnail } from "@skyhelperbot/utils";
 import { CustomId } from "@/utils/customId-store";
 import { LeaderboardCard, type LeaderboardUserData } from "@/utils/image-generators/LeaderBoardCard";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 const modalComponent = (id: string, word: string): APIModalInteractionResponseCallbackData => ({
   custom_id: "skygame_hangman_word_modal" + `-${id}`,
   title: "Provide a Word",
@@ -338,7 +338,7 @@ export const getCardResponse = async (
   return { files, components: [comp], attachments: [], flags: MessageFlags.IsComponentsV2 };
 };
 
-function createGameInstrunctionEmbed(mode: string, t: ReturnType<typeof getTranslator>) {
+function createGameInstrunctionEmbed(mode: string, t: TranslatorType) {
   const modeInstruction =
     mode === "single" ? t("features:hangman.INSTRUCTIONS_SINGLE") : t("features:hangman.INSTRUCTIONS_DOUBLE");
   const instructions = `${t("features:hangman.INSTRUCTIONS_BASE")}\n- ${modeInstruction}`;

--- a/packages/skyhelper/src/bot/modules/inputCommands/info/daily-quests.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/info/daily-quests.ts
@@ -3,7 +3,7 @@ import type { Command, SkyHelper } from "@/structures";
 import { DateTime } from "luxon";
 import { textDisplay, separator } from "@skyhelperbot/utils";
 
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import { DAILY_QUESTS_DATA } from "@/modules/commands-data/info-commands";
 import { MessageFlags } from "@discordjs/core";
 export default {
@@ -15,7 +15,7 @@ export default {
   ...DAILY_QUESTS_DATA,
 } satisfies Command;
 
-const getQuestResponse = async (client: SkyHelper, t: ReturnType<typeof getTranslator>) => {
+const getQuestResponse = async (client: SkyHelper, t: TranslatorType) => {
   const data = await client.schemas.getDailyQuests();
   const now = DateTime.now().setZone(client.timezone).startOf("day");
   const lastUpdated = DateTime.fromISO(data.last_updated, { zone: client.timezone }).startOf("day");

--- a/packages/skyhelper/src/bot/modules/inputCommands/info/shards-calendar.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/info/shards-calendar.ts
@@ -5,9 +5,13 @@ import { MessageFlags } from "@discordjs/core";
 export default {
   async interactionRun({ t, helper, options }) {
     const hide = options.getBoolean("hide") ?? false;
-    await helper.reply({
-      ...buildCalendarResponse(t, helper.client, helper.user.id),
-      flags: MessageFlags.IsComponentsV2 | (hide ? MessageFlags.Ephemeral : 0),
+    await helper.defer({ flags: hide ? MessageFlags.Ephemeral : undefined });
+
+    const response = await buildCalendarResponse(t, helper.user.id);
+
+    await helper.editReply({
+      ...response,
+      flags: MessageFlags.IsComponentsV2,
     });
   },
   ...SHARDS_CALENDAR_DATA,

--- a/packages/skyhelper/src/bot/modules/inputCommands/info/shards.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/info/shards.ts
@@ -1,6 +1,6 @@
 import type { Command } from "@/structures";
 import { ShardsUtil } from "@skyhelperbot/utils";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import { SHARDS_DATA } from "@/modules/commands-data/info-commands";
 import { MessageFlags, type APIInteractionResponseCallbackData } from "@discordjs/core";
 import { buildShardEmbed } from "@/utils/classes/Embeds";
@@ -25,7 +25,7 @@ export default {
 } satisfies Command;
 
 const getShards = (
-  t: ReturnType<typeof getTranslator>,
+  t: TranslatorType,
   user: string,
   settings: UserSchema,
   date?: string | null,

--- a/packages/skyhelper/src/bot/modules/inputCommands/info/ts.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/info/ts.ts
@@ -1,5 +1,5 @@
 import type { Command, SkyHelper } from "@/structures";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import { TRAVELING_SPIRITS_DATA } from "@/modules/commands-data/info-commands";
 import { MessageFlags, type APIInteractionResponseCallbackData, type APIUser } from "@discordjs/core";
 import { container, separator, textDisplay } from "@skyhelperbot/utils";
@@ -17,7 +17,7 @@ export default {
 
 const getTSResponse = async (
   client: SkyHelper,
-  t: ReturnType<typeof getTranslator>,
+  t: TranslatorType,
   user: APIUser,
 ): Promise<APIInteractionResponseCallbackData> => {
   const baseTs = getNextTs();

--- a/packages/skyhelper/src/bot/modules/inputCommands/utility/calculator.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/utility/calculator.ts
@@ -1,4 +1,4 @@
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import { CALCULATOR_DATA } from "@/modules/commands-data/utility-commands";
 import { fetchSkyData, PlannerDataService, PlannerService } from "@/planner";
 import type { Command } from "@/structures";
@@ -28,7 +28,7 @@ export function getCandlesModal(
   type: CandleType,
   settings: UserSchema,
   skyData: Awaited<ReturnType<typeof fetchSkyData>>,
-  t: ReturnType<typeof getTranslator>,
+  t: TranslatorType,
 ): APIModalInteractionResponseCallbackData {
   const activeSeason = PlannerService.getCurrentSeason(skyData);
 
@@ -104,7 +104,7 @@ function buildCheckboxes(
   type: CandleType,
   settings: UserSchema,
   activeSeason: ReturnType<typeof PlannerService.getCurrentSeason>,
-  t: ReturnType<typeof getTranslator>,
+  t: TranslatorType,
 ): APICheckboxGroupOption[] {
   const checkboxes: APICheckboxGroupOption[] = [];
 

--- a/packages/skyhelper/src/bot/modules/inputCommands/utility/planner.ts
+++ b/packages/skyhelper/src/bot/modules/inputCommands/utility/planner.ts
@@ -7,6 +7,7 @@ import { plannerData, searchHelper } from "./sub/planner.helpers.js";
 import { fetchSkyData, handlePlannerNavigation, PlannerService } from "@/planner";
 import { MessageFlags } from "discord-api-types/v10";
 import type { ISkyData } from "skygame-data";
+
 //  this is mappings of available display tabs that will show on search, which users can quick jump to
 const tab_mappings = (data: ISkyData) => [
   ...Object.entries(DisplayTabs).map(([n, v]) => ({ name: n, path: { t: v } })),

--- a/packages/skyhelper/src/bot/structures/Button.ts
+++ b/packages/skyhelper/src/bot/structures/Button.ts
@@ -1,5 +1,5 @@
 import type { APIMessageComponentButtonInteraction } from "@discordjs/core";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import type { InteractionHelper } from "@/utils/classes/InteractionUtil";
 import type { Awaitable } from "@/types/utils";
 import type { CustomId, store } from "@/utils/customId-store";
@@ -20,7 +20,7 @@ export interface Button<T extends CustomId> {
   /** The callback for when the button is clicked */
   execute: (
     interaction: APIMessageComponentButtonInteraction,
-    t: ReturnType<typeof getTranslator>,
+    t: TranslatorType,
     helper: InteractionHelper,
     props: (ReturnType<typeof store.deserialize> & { id: T })["data"],
   ) => Awaitable<void>;

--- a/packages/skyhelper/src/bot/structures/Command.d.ts
+++ b/packages/skyhelper/src/bot/structures/Command.d.ts
@@ -9,7 +9,7 @@ import type {
 import type { InteractionOptionResolver } from "@sapphire/discord-utilities";
 import type { SkyHelper } from "./Client.ts";
 import type { Awaitable, OverrideLocalizations } from "@/types/utils";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import type { PermissionsResolvable } from "@/utils/classes/PermissionUtils";
 import type { MessageFlags } from "@/utils/classes/MessageFlags";
 import type { Category } from "./Category.ts";
@@ -19,7 +19,7 @@ interface MessageParams {
   message: GatewayMessageCreateDispatchData;
   args: string[];
   flags: MessageFlags;
-  t: ReturnType<typeof getTranslator>;
+  t: TranslatorType;
   client: SkyHelper;
 }
 
@@ -107,7 +107,7 @@ interface InteractionOptions<
 > {
   interaction: TType;
   helper: InteractionHelper;
-  t: ReturnType<typeof getTranslator>;
+  t: TranslatorType;
   options: InteractionOptionResolver;
 }
 export type Command<Autocomplete extends boolean = false> = (Autocomplete extends true

--- a/packages/skyhelper/src/bot/utils/classes/Embeds.ts
+++ b/packages/skyhelper/src/bot/utils/classes/Embeds.ts
@@ -5,13 +5,14 @@ import {
   MessageFlags,
   type APIActionRowComponent,
   type APIButtonComponent,
+  type APIComponentInContainer,
   type APIContainerComponent,
   type APIMessageTopLevelComponent,
   type APIStringSelectComponent,
 } from "@discordjs/core";
 import { DateTime } from "luxon";
 import Utils from "./Utils.js";
-import type { getTranslator } from "@/i18n";
+import type { getTranslator, TranslatorType } from "@/i18n";
 import {
   eventData,
   SkytimesUtils as skyutils,
@@ -33,7 +34,8 @@ import type { InteractionHelper } from "./InteractionUtil.js";
 import { createActionId } from "@/planner/helpers/action.utils";
 import { PlannerAction } from "@/types/planner";
 import { fetchSkyData, PlannerService } from "@/planner";
-
+import { LRUCache } from "lru-cache";
+import { generateShardsCalendarCard } from "../image-generators/ShardsCalendarCard.js";
 /**
  * @param date The date for which the shards embed is to be built
  * @param footer The footer text for the embed
@@ -159,7 +161,7 @@ export function buildShardEmbed(
  * @param text text to include in the footer
  * @returns
  */
-export async function getTimesEmbed(client: SkyHelper, t: ReturnType<typeof getTranslator>) {
+export async function getTimesEmbed(client: SkyHelper, t: TranslatorType) {
   const plannerData = await fetchSkyData(client);
   const tsData = getNextTs();
   const specialEvent = PlannerService.getEvents(plannerData).current[0];
@@ -250,7 +252,7 @@ export async function getTimesEmbed(client: SkyHelper, t: ReturnType<typeof getT
   };
 }
 
-export function dailyQuestEmbed(data: DailyQuestsSchema, t: ReturnType<typeof getTranslator>) {
+export function dailyQuestEmbed(data: DailyQuestsSchema, t: TranslatorType) {
   const { quests, seasonal_candles } = data;
   const total = quests.length;
   const now = DateTime.now().setZone("America/Los_Angeles").startOf("day");
@@ -311,19 +313,31 @@ export function dailyQuestEmbed(data: DailyQuestsSchema, t: ReturnType<typeof ge
   return { components: [component] };
 }
 
-export function buildCalendarResponse(
-  t: ReturnType<typeof getTranslator>,
-  client: SkyHelper,
+const calendarCache = new LRUCache<string, Buffer>({
+  max: 200,
+  /* // only for debugging
+  onInsert: (value: Buffer, key: string) => {
+    console.log(key);
+  }, */
+  fetchMethod: async (key: string) => {
+    const [month, year] = key.split("-").map(Number);
+
+    return await generateShardsCalendarCard({ month, year });
+  },
+});
+
+/**
+ * Returns legacy way of displaying shards calendar
+ */
+function getLegacyCalendarDescription(
+  { index, month, year }: Required<Omit<ResponseParams, "index">> & Pick<ResponseParams, "index">,
+  now: DateTime,
+  t: TranslatorType,
   userId: string,
-  { index, month, year }: ResponseParams = {},
 ) {
-  const now = DateTime.now().setZone("America/Los_Angeles");
-  const date = 1;
-  month ??= now.month;
-  const monthStr = CalendarMonths[month - 1];
-  year ??= now.year;
   const datesArray = getDates(now);
 
+  const date = 1;
   const setsOfDates = [];
   for (let i = 0; i < datesArray.length; i += 5) {
     setsOfDates.push(datesArray.slice(i, i + 5));
@@ -337,7 +351,25 @@ export function buildCalendarResponse(
   const start = index * 5;
   const end = start + 5;
   const toDisplay = dates.slice(start, end);
-  const title = `${toDisplay[0]!.toFormat("DD")} - ${toDisplay[toDisplay.length - 1]!.toFormat("DD")}`;
+
+  const description =
+    toDisplay.map((d) => {
+      const { currentRealm, currentShard } = utils.shardsIndex(d);
+      const timelines = shardsTimeline(d)[currentShard];
+      const noShard = utils.getStatus(d);
+      const info = shardsInfo[currentRealm]![currentShard]!;
+      let desc = `**${
+        d.hasSame(now, "day")
+          ? Utils.time(d.toUnixInteger(), "D") + ` (${t("features:shards-embed.TODAY")}) <a:uptime:1228956558113771580>`
+          : Utils.time(d.toUnixInteger(), "D")
+      }**\n`;
+      desc +=
+        typeof noShard === "string"
+          ? emojis.tree_end + t("commands:SHARDS_CALENDAR.RESPONSES.INFO.NO_SHARD")
+          : `${emojis.tree_middle}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-INFO", { INFO: info.type === "red" ? `${Utils.formatEmoji(emojis.red_shard, "RedShard")} Red Shard` : `${Utils.formatEmoji(emojis.black_shard, "BlackShard")} Black Shard`, AREA: `*${info.area}*` })}\n${emojis.tree_end}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-TIMES", { TIME: timelines.map((ti) => Utils.time(ti.start.toUnixInteger(), "T")).join(" • ") })}`;
+      return desc;
+    }) + `\n-# ${t("commands:SHARDS_CALENDAR.RESPONSES.EMBED_FOOTER", { INDEX: index + 1, TOTAL: totalPages })}`;
+
   const navBtn: APIActionRowComponent<APIButtonComponent> = {
     type: 1,
     components: [
@@ -367,35 +399,51 @@ export function buildCalendarResponse(
       },
     ],
   };
-  const description = toDisplay
-    .map((d) => {
-      const { currentRealm, currentShard } = utils.shardsIndex(d);
-      const timelines = shardsTimeline(d)[currentShard];
-      const noShard = utils.getStatus(d);
-      const info = shardsInfo[currentRealm]![currentShard]!;
-      let desc = `**${
-        d.hasSame(now, "day")
-          ? client.utils.time(d.toUnixInteger(), "D") + ` (${t("features:shards-embed.TODAY")}) <a:uptime:1228956558113771580>`
-          : client.utils.time(d.toUnixInteger(), "D")
-      }**\n`;
-      desc +=
-        typeof noShard === "string"
-          ? emojis.tree_end + t("commands:SHARDS_CALENDAR.RESPONSES.INFO.NO_SHARD")
-          : `${emojis.tree_middle}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-INFO", { INFO: info.type === "red" ? `${Utils.formatEmoji(emojis.red_shard, "RedShard")} Red Shard` : `${Utils.formatEmoji(emojis.black_shard, "BlackShard")} Black Shard`, AREA: `*${info.area}*` })}\n${emojis.tree_end}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-TIMES", { TIME: timelines.map((ti) => client.utils.time(ti.start.toUnixInteger(), "T")).join(" • ") })}`;
-      return desc;
-    })
-    .join("\n\n");
+
+  const title = `${toDisplay[0]!.toFormat("DD")} - ${toDisplay[toDisplay.length - 1]!.toFormat("DD")}`;
+  return { description: description, navBtn, title };
+}
+
+export async function buildCalendarResponse(
+  t: TranslatorType,
+  userId: string,
+  { index, month, year }: ResponseParams = {},
+  legacy = false,
+) {
+  const now = DateTime.now().setZone("America/Los_Angeles");
+  month ??= now.month;
+  const monthStr = CalendarMonths[month - 1];
+  year ??= now.year;
+
+  let calendarDisplay: APIComponentInContainer[];
+  let calendarBuffer: Buffer | null = null;
+  let title: string;
+  if (legacy) {
+    const { description, navBtn, title: legacyTitle } = getLegacyCalendarDescription({ index, month, year }, now, t, userId);
+
+    calendarDisplay = [textDisplay(description), separator(), navBtn];
+    title = legacyTitle;
+  } else {
+    const cacheKey = `${month}-${year}`;
+
+    calendarBuffer = (await calendarCache.fetch(cacheKey, { allowStale: true }))!;
+
+    title = "Shards Calendar";
+
+    calendarDisplay = [mediaGallery(mediaGalleryItem("attachment://calendar.png"))];
+  }
 
   const component = container(
     section(
       {
         type: 2,
-        custom_id: Utils.store.serialize(Utils.customId.CalendarDate, {
+        custom_id: Utils.store.serialize(Utils.customId.CalendarToggle, {
           month: month,
           year: year,
           user: userId,
+          legacy,
         }),
-        label: t("commands:SHARDS_CALENDAR.RESPONSES.CHANGE_BUTTON"),
+        label: `${monthStr}/${year}`,
         style: 2,
       },
       `-# ${t("commands:SHARDS_CALENDAR.RESPONSES.EMBED_AUTHOR", { MONTH: monthStr, YEAR: year })}\n### ${title}\n${t(
@@ -404,11 +452,33 @@ export function buildCalendarResponse(
       )}\n`,
     ),
     separator(),
-    textDisplay(
-      description + `\n-# ${t("commands:SHARDS_CALENDAR.RESPONSES.EMBED_FOOTER", { INDEX: index + 1, TOTAL: totalPages })}`,
-    ),
+    ...calendarDisplay,
   );
-  return { components: [component, container(navBtn)] };
+
+  return {
+    components: [
+      component,
+      row({
+        type: ComponentType.StringSelect,
+        custom_id: Utils.store.serialize(Utils.customId.CalendarToggle, { month, year, user: userId, legacy: null }),
+        options: [
+          {
+            label: t("commands:SHARDS_CALENDAR.RESPONSES.SELECT_INFOGRAPHICS"),
+            value: "infographics",
+            default: !legacy,
+            description: t("commands:SHARDS_CALENDAR.RESPONSES.SELECT_INFOGRAPHICS_DESCRIPTION").slice(0, 100),
+          },
+          {
+            label: t("commands:SHARDS_CALENDAR.RESPONSES.SELECT_LEGACY"),
+            value: "legacy",
+            default: legacy,
+            description: t("commands:SHARDS_CALENDAR.RESPONSES.SELECT_LEGACY_DESCRIPTION").slice(0, 100),
+          },
+        ],
+      }),
+    ],
+    files: calendarBuffer ? [{ data: calendarBuffer, name: "calendar.png" }] : [],
+  };
 }
 
 export async function handleRemindersStatus(helper: InteractionHelper, guildSettings: GuildSchema, guildName: string, page = 0) {

--- a/packages/skyhelper/src/bot/utils/classes/Embeds.ts
+++ b/packages/skyhelper/src/bot/utils/classes/Embeds.ts
@@ -315,6 +315,7 @@ export function dailyQuestEmbed(data: DailyQuestsSchema, t: TranslatorType) {
 
 const calendarCache = new LRUCache<string, Buffer>({
   max: 200,
+  ttlAutopurge: true,
   /* // only for debugging
   onInsert: (value: Buffer, key: string) => {
     console.log(key);
@@ -353,22 +354,24 @@ function getLegacyCalendarDescription(
   const toDisplay = dates.slice(start, end);
 
   const description =
-    toDisplay.map((d) => {
-      const { currentRealm, currentShard } = utils.shardsIndex(d);
-      const timelines = shardsTimeline(d)[currentShard];
-      const noShard = utils.getStatus(d);
-      const info = shardsInfo[currentRealm]![currentShard]!;
-      let desc = `**${
-        d.hasSame(now, "day")
-          ? Utils.time(d.toUnixInteger(), "D") + ` (${t("features:shards-embed.TODAY")}) <a:uptime:1228956558113771580>`
-          : Utils.time(d.toUnixInteger(), "D")
-      }**\n`;
-      desc +=
-        typeof noShard === "string"
-          ? emojis.tree_end + t("commands:SHARDS_CALENDAR.RESPONSES.INFO.NO_SHARD")
-          : `${emojis.tree_middle}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-INFO", { INFO: info.type === "red" ? `${Utils.formatEmoji(emojis.red_shard, "RedShard")} Red Shard` : `${Utils.formatEmoji(emojis.black_shard, "BlackShard")} Black Shard`, AREA: `*${info.area}*` })}\n${emojis.tree_end}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-TIMES", { TIME: timelines.map((ti) => Utils.time(ti.start.toUnixInteger(), "T")).join(" • ") })}`;
-      return desc;
-    }) + `\n-# ${t("commands:SHARDS_CALENDAR.RESPONSES.EMBED_FOOTER", { INDEX: index + 1, TOTAL: totalPages })}`;
+    toDisplay
+      .map((d) => {
+        const { currentRealm, currentShard } = utils.shardsIndex(d);
+        const timelines = shardsTimeline(d)[currentShard];
+        const noShard = utils.getStatus(d);
+        const info = shardsInfo[currentRealm]![currentShard]!;
+        let desc = `**${
+          d.hasSame(now, "day")
+            ? Utils.time(d.toUnixInteger(), "D") + ` (${t("features:shards-embed.TODAY")}) <a:uptime:1228956558113771580>`
+            : Utils.time(d.toUnixInteger(), "D")
+        }**\n`;
+        desc +=
+          typeof noShard === "string"
+            ? emojis.tree_end + t("commands:SHARDS_CALENDAR.RESPONSES.INFO.NO_SHARD")
+            : `${emojis.tree_middle}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-INFO", { INFO: info.type === "red" ? `${Utils.formatEmoji(emojis.red_shard, "RedShard")} Red Shard` : `${Utils.formatEmoji(emojis.black_shard, "BlackShard")} Black Shard`, AREA: `*${info.area}*` })}\n${emojis.tree_end}${t("commands:SHARDS_CALENDAR.RESPONSES.INFO.SHARD-TIMES", { TIME: timelines.map((ti) => Utils.time(ti.start.toUnixInteger(), "T")).join(" • ") })}`;
+        return desc;
+      })
+      .join("\n\n") + `\n-# ${t("commands:SHARDS_CALENDAR.RESPONSES.EMBED_FOOTER", { INDEX: index + 1, TOTAL: totalPages })}`;
 
   const navBtn: APIActionRowComponent<APIButtonComponent> = {
     type: 1,
@@ -424,9 +427,18 @@ export async function buildCalendarResponse(
     calendarDisplay = [textDisplay(description), separator(), navBtn];
     title = legacyTitle;
   } else {
-    const cacheKey = `${month}-${year}`;
+    const baseKey = `${month}-${year}`;
 
-    calendarBuffer = (await calendarCache.fetch(cacheKey, { allowStale: true }))!;
+    const isCurrentMonth = now.month === month && now.year === year;
+
+    // cache per-day basis for the current month since it highlights current day differently
+    // caching on month basis may show incorrect today's date
+    const cacheKey = isCurrentMonth ? baseKey + `-${now.toFormat("dd")}` : baseKey;
+
+    calendarBuffer = (await calendarCache.fetch(cacheKey, {
+      // cache for 1 day if current month
+      ttl: isCurrentMonth ? 10000 * 6 * 6 * 24 : undefined,
+    }))!;
 
     title = "Shards Calendar";
 

--- a/packages/skyhelper/src/bot/utils/classes/InteractionUtil.ts
+++ b/packages/skyhelper/src/bot/utils/classes/InteractionUtil.ts
@@ -1,5 +1,5 @@
 import type { ComponentInteractionMap } from "@/@types/interactions";
-import { getTranslator } from "@/i18n";
+import { getTranslator, type TranslatorType } from "@/i18n";
 import type { SkyHelper } from "@/structures/Client";
 import type { UserSchema } from "@/types/schemas";
 import {
@@ -30,7 +30,7 @@ export class InteractionHelper {
   public deferred = false;
   public api: API;
   public user: APIUser;
-  public t: ReturnType<typeof getTranslator> = getTranslator("en-US");
+  public t: TranslatorType = getTranslator("en-US");
   private userSettings: UserSchema | null = null;
   constructor(
     public readonly int: APIInteraction,

--- a/packages/skyhelper/src/bot/utils/classes/Spirits.ts
+++ b/packages/skyhelper/src/bot/utils/classes/Spirits.ts
@@ -1,5 +1,5 @@
 import type { SkyHelper } from "@/structures";
-import { getTranslator } from "@/i18n";
+import { getTranslator, type TranslatorType } from "@/i18n";
 import { ButtonStyle, type APIActionRowComponent, type APIButtonComponent } from "@discordjs/core";
 import utils from "./Utils.js";
 import { button, container, section, separator, textDisplay, thumbnail } from "@skyhelperbot/utils";
@@ -42,7 +42,7 @@ const getExpressionBtn = (data: ISpirit, user: string): APIButtonComponent => ({
 export class Spirits {
   constructor(
     private data: ISpirit,
-    private t: ReturnType<typeof getTranslator>,
+    private t: TranslatorType,
     private client: SkyHelper,
     private plannerData: ISkyData,
   ) {}

--- a/packages/skyhelper/src/bot/utils/customId-store.ts
+++ b/packages/skyhelper/src/bot/utils/customId-store.ts
@@ -6,7 +6,10 @@ export enum CustomId {
   SpiritCollectible,
   SpiritExpression,
   BugReports,
-  CalendarDate,
+  /**
+   * Used for both calendar type selection select and button that launches modal for month/year selection
+   */
+  CalendarToggle,
   CalenderNav,
   ShardsScroll,
   TimesRefresh,
@@ -42,7 +45,14 @@ export const store = new SchemaStore()
   .add(new Schema(CustomId.SpiritCollectible).string("spirit").nullable("user", t.string))
   .add(new Schema(CustomId.SpiritExpression).string("spirit").nullable("user", t.string))
   .add(new Schema(CustomId.BugReports).string("error").nullable("user", t.string))
-  .add(new Schema(CustomId.CalendarDate).uint4("month").uint32("year").nullable("user", t.string))
+  .add(
+    new Schema(CustomId.CalendarToggle)
+      .uint4("month")
+      .uint32("year")
+      // nullable because the same schema is used for calendar type select menu, and legacy is set by it's option's selection
+      .nullable("legacy", t.boolean)
+      .nullable("user", t.string),
+  )
   .add(new Schema(CustomId.CalenderNav).uint4("month").uint32("year").uint4("index").nullable("user", t.string))
   .add(new Schema(CustomId.ShardsScroll).string("date").nullable("user", t.string))
   .add(new Schema(CustomId.TimesRefresh).nullable("user", t.string))

--- a/packages/skyhelper/src/bot/utils/image-generators/ShardsCalendarCard.ts
+++ b/packages/skyhelper/src/bot/utils/image-generators/ShardsCalendarCard.ts
@@ -29,7 +29,7 @@ const CELL_HEIGHT = 162;
 const BOTTOM_PAD = 30;
 
 // Weekday labels
-const WEEKDAYS = ["Mon", "Tue", "Wed", "Thur", "Fri", "Sat", "Sun"] as const;
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 
 // Short realm labels used on the image
 const REALM_SHORT_NAMES: Record<string, string> = {
@@ -61,7 +61,7 @@ export interface ShardsCalendarDayData {
   location: string;
   /** Short realm name (e.g. "Prairie") */
   realm: string;
-  /** Reward string (e.g. "200 wax" / "3.5 AC"), or null when unknown */
+  /** Reward, or null when unknown */
   reward: number | null;
   /** Shard time windows formatted as "HH:mm-HH:mm" (absolute, shard timezone) */
   timings: string[];
@@ -163,51 +163,6 @@ function drawBackground(ctx: SKRSContext2D, width: number, height: number) {
     }
   }
   ctx.restore();
-}
-
-/** Draw the tiny reference legend (red/black/no-shard swatches) top-left, above the weekday divider */
-function drawLegend(ctx: SKRSContext2D, padding: number, px: (n: number) => number) {
-  const items = [
-    { colors: CARD_COLORS.red, label: "Red Shard" },
-    { colors: CARD_COLORS.black, label: "Black Shard" },
-    { colors: CARD_COLORS.none, label: "No Shard" },
-  ] as const;
-
-  const swatchSize = px(25);
-  const gap = px(14);
-  const textSize = px(20);
-  const rowHeight = px(22);
-  const startY = px(HEADER_TOP + 20);
-
-  ctx.font = font(textSize, FONT_BOLD);
-  ctx.fillStyle = "#bdb6cc";
-  ctx.textAlign = "left";
-  ctx.textBaseline = "middle";
-
-  items.forEach((item, i) => {
-    const y = startY + i * (rowHeight + gap);
-    // tiny reference swatch (only color, no content)
-    ctx.save();
-    roundedRectPath(ctx, padding, y, swatchSize, swatchSize, px(4));
-    ctx.fillStyle = item.colors.tint;
-    ctx.fill();
-    ctx.strokeStyle = item.colors.border;
-    ctx.lineWidth = 1;
-    ctx.stroke();
-    ctx.restore();
-    // label beside the swatch, separated by a hyphen
-    ctx.fillText(`- ${item.label}`, padding + swatchSize + px(8), y + swatchSize / 2);
-  });
-
-  const todayX = padding + swatchSize + px(8) + ctx.measureText(`- ${items[0].label}`).width + px(60);
-  ctx.save();
-  roundedRectPath(ctx, todayX, startY, swatchSize, swatchSize, px(4));
-
-  ctx.strokeStyle = CARD_COLORS.todayColor;
-  ctx.lineWidth = 1;
-  ctx.stroke();
-  ctx.restore();
-  ctx.fillText(`- Today's date`, todayX + swatchSize + px(8), startY + swatchSize / 2);
 }
 
 /** Wrap text to fit `maxWidth`, at most `maxLines` lines (last line ellipsized on overflow) */
@@ -416,7 +371,7 @@ export async function generateShardsCalendarCard(options: ShardsCalendarCardOpti
   // #region Header (bot logo + name, centered title)
   await drawBotTitleHeader({ botIcon, botName, headerY: px(28), size: px(18), ctx });
 
-  const titleY = px(HEADER_TOP + 62);
+  const titleY = px(HEADER_TOP + 30);
   ctx.font = `${px(54)}px ${FONT_BOLD}`;
   ctx.fillStyle = "#F6EAE0";
   ctx.textAlign = "center";
@@ -427,6 +382,24 @@ export async function generateShardsCalendarCard(options: ShardsCalendarCardOpti
   ctx.fillStyle = "#c9c2d9";
   ctx.fillText(`${CalendarMonths[month - 1]} ${year}`, width / 2, titleY + px(52));
 
+  // timing disclaimer
+  ctx.font = `${px(20)}px ${FONT_NAME}`;
+  ctx.fillStyle = "#6e6e7e";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(
+    `All timings shown after the daily reset (12 AM Los Angeles time; UTC ${now.toFormat("ZZ")})`,
+    width / 2,
+    titleY + px(100),
+  );
+
+  // generated on text
+  ctx.font = `${px(20)}px ${FONT_NAME}`;
+  ctx.fillStyle = "#6e6e7e";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  ctx.fillText(`Generated on: ${now.toFormat("dd/MM/yyyy")}`, padding, 20);
+
   // divider
   ctx.strokeStyle = "rgba(255,255,255,0.08)";
   ctx.lineWidth = 1;
@@ -434,10 +407,6 @@ export async function generateShardsCalendarCard(options: ShardsCalendarCardOpti
   ctx.moveTo(padding, px(HEADER_TOP + HEADER_HEIGHT - 6));
   ctx.lineTo(width - padding, px(HEADER_TOP + HEADER_HEIGHT - 6));
   ctx.stroke();
-
-  // reference legend
-  drawLegend(ctx, padding, px);
-  // #endregion
 
   // #region Weekday headers
   const weekdayY = px(HEADER_TOP + HEADER_HEIGHT + 24);
@@ -477,14 +446,6 @@ export async function generateShardsCalendarCard(options: ShardsCalendarCardOpti
       drawCell(render, cellX, rowY, cellW, cellH, cell, icon);
     }
   }
-  // #endregion
-
-  // #region Footer note
-  ctx.font = `${px(20)}px ${FONT_NAME}`;
-  ctx.fillStyle = "#6e6e7e";
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  ctx.fillText("All timings shown after the daily reset (12 AM Los Angeles time)", width / 2, height - px(BOTTOM_PAD / 2));
   // #endregion
 
   return canvas.encode("png");

--- a/packages/skyhelper/src/bot/utils/image-generators/ShardsCalendarCard.ts
+++ b/packages/skyhelper/src/bot/utils/image-generators/ShardsCalendarCard.ts
@@ -1,0 +1,492 @@
+import { createCanvas, loadImage, GlobalFonts, type Canvas, type Image, type SKRSContext2D } from "@napi-rs/canvas";
+import { DateTime } from "luxon";
+import path from "node:path";
+import { ShardsUtil } from "@skyhelperbot/utils";
+import { currency, emojis, zone } from "@skyhelperbot/constants";
+import config from "@/config";
+import { CalendarMonths } from "@/utils/constants";
+import { drawBotTitleHeader } from "./shared.js";
+
+// #region Constants
+const ZONE = zone;
+/** Build the image URL of a custom Discord emoji from its id */
+const EMOJI_URL = (emoji: string) => `https://cdn.discordapp.com/emojis/${emoji}.png`;
+
+const FONT_NAME = "noto-sans";
+const FONT_BOLD = "noto-sans-bold";
+
+GlobalFonts.registerFromPath(path.join(process.cwd(), `assets/fonts/NotoSans-Regular.ttf`), FONT_NAME);
+GlobalFonts.registerFromPath(path.join(process.cwd(), `assets/fonts/notosans-black.ttf`), FONT_BOLD);
+
+// Layout in base units (multiplied by `scale` at render time)
+const WIDTH = 2000;
+const PADDING = 40;
+const GAP = 16;
+const HEADER_TOP = 30;
+const HEADER_HEIGHT = 160;
+const WEEKDAY_HEIGHT = 55;
+const CELL_HEIGHT = 162;
+const BOTTOM_PAD = 30;
+
+// Weekday labels
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thur", "Fri", "Sat", "Sun"] as const;
+
+// Short realm labels used on the image
+const REALM_SHORT_NAMES: Record<string, string> = {
+  prairie: "Prairie",
+  forest: "Forest",
+  valley: "Valley",
+  wasteland: "Wasteland",
+  vault: "Vault",
+};
+
+const CARD_COLORS = {
+  red: { tint: "rgba(224, 90, 90, 0.14)", border: "#e06a6a" },
+  black: { tint: "rgba(18, 18, 26, 0.4)", border: "#777783" },
+  none: { tint: "rgba(255, 255, 255, 0.06)", border: "#3a3a42" },
+  todayColor: "#20d80c",
+  acColor: "#e06a6a",
+  waxColor: "#ffc46b",
+} as const;
+// #endregion
+
+// #region Data
+/** Per-day data used to render a calendar cell */
+export interface ShardsCalendarDayData {
+  /** The day this entry represents */
+  date: DateTime;
+  /** Shard type, or null on no-shard days */
+  type: "red" | "black" | null;
+  /** Short area name (e.g. "Butterfly Fields") */
+  location: string;
+  /** Short realm name (e.g. "Prairie") */
+  realm: string;
+  /** Reward string (e.g. "200 wax" / "3.5 AC"), or null when unknown */
+  reward: number | null;
+  /** Shard time windows formatted as "HH:mm-HH:mm" (absolute, shard timezone) */
+  timings: string[];
+}
+
+/** Returns every day of the given month in the shard timezone */
+export function getMonthDays(month: number, year: number): DateTime[] {
+  const first = DateTime.fromObject({ year, month, day: 1 }, { zone: ZONE });
+  if (!first.isValid) return [];
+  const totalDays = first.daysInMonth;
+  const days: DateTime[] = [];
+  for (let i = 1; i <= totalDays; i++) {
+    days.push(DateTime.fromObject({ year, month, day: i }, { zone: ZONE }));
+  }
+  return days;
+}
+
+/** Build the display data for a single day; returns null on no-shard days */
+export function buildDayData(date: DateTime): ShardsCalendarDayData | null {
+  const shard = ShardsUtil.getShard(date);
+  if (!shard) {
+    return { date, type: null, location: "", realm: "", reward: null, timings: [] };
+  }
+  const { info, timings } = shard;
+  const { currentRealm } = ShardsUtil.shardsIndex(date);
+  // `info.area` embeds a custom emoji,so strip it
+  // TODO: This should be temporary, instead of hardcoding stuff, refactor shard data to be generated dynamically with only necessary info
+  const shortName = info.area.split(",")[0]?.trim() ?? info.area;
+  return {
+    date,
+    type: info.type,
+    location: shortName,
+    realm: REALM_SHORT_NAMES[currentRealm] ?? currentRealm,
+    reward: info.wax ?? info.ac ?? null,
+    timings: timings.map((t) => `${t.start.toFormat("HH:mm")}-${t.end.toFormat("HH:mm")}`),
+  };
+}
+
+/** Build the Monday-first grid of cells for a month, padded with `null` for empty slots */
+export function getCalendarGrid(month: number, year: number): Array<Array<ShardsCalendarDayData | null>> {
+  const days = getMonthDays(month, year);
+  if (!days.length) return [];
+  const leading = days[0]!.weekday - 1; // 0 = Monday
+  const cells: Array<ShardsCalendarDayData | null> = [];
+  for (let i = 0; i < leading; i++) cells.push(null);
+  for (const day of days) cells.push(buildDayData(day));
+  while (cells.length % 7 !== 0) cells.push(null);
+  const rows: Array<Array<ShardsCalendarDayData | null>> = [];
+  for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+  return rows;
+}
+// #endregion
+
+// #region Image cache
+const imageCache = new Map<string, Image | null>();
+
+async function loadImageCached(url: string): Promise<Image | null> {
+  if (imageCache.has(url)) return imageCache.get(url) ?? null;
+  try {
+    const img = await loadImage(url);
+    imageCache.set(url, img);
+    return img;
+  } catch {
+    imageCache.set(url, null);
+    return null;
+  }
+}
+// #endregion
+
+// #region Canvas helpers
+function roundedRectPath(ctx: SKRSContext2D, x: number, y: number, w: number, h: number, r: number) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
+
+/** Build a canvas font shorthand string */
+const font = (size: number, family: string) => `${size}px ${family}`;
+
+/** Draw the card background (dark gradient + subtle dot pattern) */
+function drawBackground(ctx: SKRSContext2D, width: number, height: number) {
+  const bg = ctx.createLinearGradient(0, 0, 0, height);
+  bg.addColorStop(0, "#1e2136");
+  bg.addColorStop(1, "#0e0f1c");
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, width, height);
+
+  // subtle dot pattern
+  ctx.save();
+  ctx.globalAlpha = 0.04;
+  ctx.fillStyle = "#ffffff";
+  for (let i = 0; i < width; i += 22) {
+    for (let j = 0; j < height; j += 22) {
+      ctx.fillRect(i, j, 1, 1);
+    }
+  }
+  ctx.restore();
+}
+
+/** Draw the tiny reference legend (red/black/no-shard swatches) top-left, above the weekday divider */
+function drawLegend(ctx: SKRSContext2D, padding: number, px: (n: number) => number) {
+  const items = [
+    { colors: CARD_COLORS.red, label: "Red Shard" },
+    { colors: CARD_COLORS.black, label: "Black Shard" },
+    { colors: CARD_COLORS.none, label: "No Shard" },
+  ] as const;
+
+  const swatchSize = px(25);
+  const gap = px(14);
+  const textSize = px(20);
+  const rowHeight = px(22);
+  const startY = px(HEADER_TOP + 20);
+
+  ctx.font = font(textSize, FONT_BOLD);
+  ctx.fillStyle = "#bdb6cc";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+
+  items.forEach((item, i) => {
+    const y = startY + i * (rowHeight + gap);
+    // tiny reference swatch (only color, no content)
+    ctx.save();
+    roundedRectPath(ctx, padding, y, swatchSize, swatchSize, px(4));
+    ctx.fillStyle = item.colors.tint;
+    ctx.fill();
+    ctx.strokeStyle = item.colors.border;
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.restore();
+    // label beside the swatch, separated by a hyphen
+    ctx.fillText(`- ${item.label}`, padding + swatchSize + px(8), y + swatchSize / 2);
+  });
+
+  const todayX = padding + swatchSize + px(8) + ctx.measureText(`- ${items[0].label}`).width + px(60);
+  ctx.save();
+  roundedRectPath(ctx, todayX, startY, swatchSize, swatchSize, px(4));
+
+  ctx.strokeStyle = CARD_COLORS.todayColor;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.restore();
+  ctx.fillText(`- Today's date`, todayX + swatchSize + px(8), startY + swatchSize / 2);
+}
+
+/** Wrap text to fit `maxWidth`, at most `maxLines` lines (last line ellipsized on overflow) */
+function wrapText(ctx: SKRSContext2D, text: string, maxWidth: number, maxLines = 2): string[] {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  let overflow = false;
+  for (const word of words) {
+    const test = current ? `${current} ${word}` : word;
+    if (current && ctx.measureText(test).width > maxWidth) {
+      lines.push(current);
+      current = word;
+      if (lines.length === maxLines) {
+        overflow = true;
+        break;
+      }
+    } else {
+      current = test;
+    }
+  }
+  if (!overflow && current) lines.push(current);
+  if (!lines.length) lines.push("");
+  if (overflow) {
+    let last = lines[maxLines - 1] ?? "";
+    while (last.length && ctx.measureText(`${last}…`).width > maxWidth) last = last.slice(0, -1);
+    lines[maxLines - 1] = `${last}…`;
+  }
+  return lines;
+}
+// #endregion
+
+// #region Cell rendering
+interface CellRenderContext {
+  ctx: SKRSContext2D;
+  today: DateTime;
+  /** Pre-blurred copy of the background, used for the frosted-glass cell bodies */
+  backdrop: Canvas;
+}
+
+function drawCell(
+  render: CellRenderContext,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  data: ShardsCalendarDayData | null,
+  icon: { shardType: Image | null; currency: Image | null } | null,
+) {
+  const { ctx, today, backdrop } = render;
+  if (!data) return; // empty leading/trailing slot
+
+  const isNoShard = data.type === null;
+  const colors = isNoShard ? CARD_COLORS.none : data.type === "red" ? CARD_COLORS.red : CARD_COLORS.black;
+  const pad = 14;
+  const isToday = data.date.hasSame(today, "day");
+
+  // Frosted glass body: blurred backdrop clipped to the rounded rect
+  ctx.save();
+  roundedRectPath(ctx, x, y, w, h, 14);
+  ctx.clip();
+  ctx.drawImage(backdrop, x, y, w, h, x, y, w, h);
+  ctx.restore();
+
+  // glass tint (like a frosted glass effect)
+  ctx.save();
+  roundedRectPath(ctx, x, y, w, h, 14);
+  ctx.fillStyle = colors.tint;
+  ctx.fill();
+  ctx.strokeStyle = isToday ? CARD_COLORS.todayColor : colors.border;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.restore();
+
+  // Row 1: day number  + shard icon
+  ctx.font = font(24, FONT_BOLD);
+  ctx.fillStyle = isToday ? CARD_COLORS.todayColor : "#F6EAE0";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  const dayStr = String(data.date.day);
+  ctx.fillText(dayStr, x + pad, y + 12);
+
+  if (isNoShard) {
+    //  "X" marker for no shard cells
+    ctx.font = font(40, FONT_BOLD);
+    ctx.fillStyle = "#5a5a66";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("X", x + w / 2, y + h / 2 + 8);
+    return;
+  }
+
+  if (icon?.shardType) {
+    const iconSize = 26;
+    ctx.drawImage(icon.shardType, x + w - pad - iconSize, y + pad - 4, iconSize, iconSize);
+  }
+
+  // Row 2: location
+  ctx.font = font(22, FONT_BOLD);
+  ctx.fillStyle = "#F6EAE0";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  const locLine = wrapText(ctx, data.location, w - pad * 2, 1)[0] ?? "";
+  ctx.fillText(locLine, x + pad, y + 48);
+
+  // Row 3: realm  + reward
+  ctx.font = font(19, FONT_NAME);
+  ctx.fillStyle = "#9b9bae";
+  ctx.fillText(data.realm, x + pad, y + 80);
+  if (data.reward) {
+    const curIcon = icon?.currency ?? null;
+    const iconSize = 22; // matches the 19px reward text
+    const unit = data.type === "red" ? "AC" : "wax";
+    const rewardStr = curIcon ? data.reward.toString() : `${data.reward} ${unit}`;
+    ctx.font = font(19, FONT_BOLD);
+    ctx.fillStyle = data.type === "red" ? CARD_COLORS.acColor : CARD_COLORS.waxColor;
+    ctx.textAlign = "right";
+    const right = x + w - pad;
+    // shift the number left to make room for the wax/AC icon
+    ctx.fillText(rewardStr, curIcon ? right - iconSize - 3 : right, y + 80);
+    if (curIcon) {
+      ctx.drawImage(curIcon, right - iconSize, y + 78, iconSize, iconSize);
+    }
+  }
+
+  // Row 4-5: absolute time windows (first two together, then the third)
+  ctx.font = font(18, FONT_NAME);
+  ctx.fillStyle = "#bdb6cc";
+  ctx.textAlign = "left";
+  const [t1, t2, t3] = data.timings;
+  if (t1) {
+    ctx.fillText(t2 ? `${t1}   ${t2}` : t1, x + pad, y + 110);
+  }
+  if (t3) {
+    ctx.fillText(t3, x + pad, y + 134);
+  }
+}
+// #endregion
+
+// #region Main generator
+export interface ShardsCalendarCardOptions {
+  /** Month to render (1-12); defaults to the current month */
+  month?: number;
+  /** Year to render; defaults to the current year */
+  year?: number;
+  /** URL of the bot icon shown in the header; defaults to `config.BOT_ICON` */
+  botIcon?: string;
+  /** Bot name shown in the header; defaults to "SkyHelper" */
+  botName?: string;
+  /** Resolution multiplier (1 = full size) */
+  scale?: number;
+}
+
+/**
+ * Generate a monthly shard calendar image.
+ *
+ * Red shard days get a reddish card, black shard days a blackish card and
+ * no-shard days a neutral card. Times are absolute `HH:mm-HH:mm` windows in the
+ * shard timezone (America/Los_Angeles), since relative timings can't be shown
+ * on a static image.
+ *
+ * @param options month/year to render plus header styling options
+ * @returns a PNG image buffer of the calendar
+ */
+export async function generateShardsCalendarCard(options: ShardsCalendarCardOptions = {}): Promise<Buffer> {
+  const now = DateTime.now().setZone(ZONE);
+  const month = options.month ?? now.month;
+  const year = options.year ?? now.year;
+  const botName = options.botName ?? "SkyHelper";
+  const botIcon = options.botIcon ?? config.BOT_ICON;
+  const scale = options.scale ?? 1;
+  const px = (n: number) => Math.round(n * scale);
+
+  const first = DateTime.fromObject({ year, month, day: 1 }, { zone: ZONE });
+  if (!first.isValid) throw new Error(`Invalid month or year: ${month}-${year}`);
+
+  const rows = getCalendarGrid(month, year);
+  if (!rows.length) throw new Error(`Invalid month or year: ${month}-${year}`);
+
+  const width = px(WIDTH);
+  const padding = px(PADDING);
+  const gap = px(GAP);
+  const cellW = Math.floor((width - padding * 2 - gap * 6) / 7);
+  const cellH = px(CELL_HEIGHT);
+  const gridTop = px(HEADER_TOP + HEADER_HEIGHT + WEEKDAY_HEIGHT);
+  const height = px(
+    HEADER_TOP + HEADER_HEIGHT + WEEKDAY_HEIGHT + rows.length * CELL_HEIGHT + (rows.length - 1) * GAP + BOTTOM_PAD,
+  );
+
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext("2d");
+
+  // #region Background
+  drawBackground(ctx, width, height);
+  // #endregion
+
+  // #region Frosted-glass backdrop (pre-blurred copy of the background)
+  const bgSharp = createCanvas(width, height);
+  drawBackground(bgSharp.getContext("2d"), width, height);
+  const bgBlur = createCanvas(width, height);
+  const bctx = bgBlur.getContext("2d");
+  bctx.filter = "blur(16px)";
+  bctx.drawImage(bgSharp, 0, 0);
+  // #endregion
+
+  // #region Header (bot logo + name, centered title)
+  await drawBotTitleHeader({ botIcon, botName, headerY: px(28), size: px(18), ctx });
+
+  const titleY = px(HEADER_TOP + 62);
+  ctx.font = `${px(54)}px ${FONT_BOLD}`;
+  ctx.fillStyle = "#F6EAE0";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("Shard Calendar", width / 2, titleY);
+
+  ctx.font = `${px(34)}px ${FONT_BOLD}`;
+  ctx.fillStyle = "#c9c2d9";
+  ctx.fillText(`${CalendarMonths[month - 1]} ${year}`, width / 2, titleY + px(52));
+
+  // divider
+  ctx.strokeStyle = "rgba(255,255,255,0.08)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(padding, px(HEADER_TOP + HEADER_HEIGHT - 6));
+  ctx.lineTo(width - padding, px(HEADER_TOP + HEADER_HEIGHT - 6));
+  ctx.stroke();
+
+  // reference legend
+  drawLegend(ctx, padding, px);
+  // #endregion
+
+  // #region Weekday headers
+  const weekdayY = px(HEADER_TOP + HEADER_HEIGHT + 24);
+  ctx.font = `${px(24)}px ${FONT_BOLD}`;
+  ctx.fillStyle = "#9b9bae";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  WEEKDAYS.forEach((label, i) => {
+    const cx = padding + cellW * i + cellW / 2 + gap * i;
+    ctx.fillText(label, cx, weekdayY);
+  });
+  // #endregion
+
+  // #region Preload images
+  const [redShardImg, blackShardImg, acImg, waxImg] = await Promise.all([
+    loadImageCached(EMOJI_URL(emojis.red_shard)),
+    loadImageCached(EMOJI_URL(emojis.black_shard)),
+    loadImageCached(EMOJI_URL(currency.ac)),
+    loadImageCached(EMOJI_URL(emojis.wax)),
+  ]);
+  // #endregion
+
+  // #region Cells
+  const render: CellRenderContext = { ctx, today: now, backdrop: bgBlur };
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r]!;
+    const rowY = gridTop + r * (cellH + gap);
+    for (let c = 0; c < row.length; c++) {
+      const cell = row[c] ?? null;
+      const cellX = padding + c * (cellW + gap);
+      const icon =
+        cell?.type === "red"
+          ? { shardType: redShardImg, currency: acImg }
+          : cell?.type === "black"
+            ? { shardType: blackShardImg, currency: waxImg }
+            : null;
+      drawCell(render, cellX, rowY, cellW, cellH, cell, icon);
+    }
+  }
+  // #endregion
+
+  // #region Footer note
+  ctx.font = `${px(20)}px ${FONT_NAME}`;
+  ctx.fillStyle = "#6e6e7e";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("All timings shown after the daily reset (12 AM Los Angeles time)", width / 2, height - px(BOTTOM_PAD / 2));
+  // #endregion
+
+  return canvas.encode("png");
+}
+// #endregion

--- a/packages/skyhelper/src/bot/utils/image-generators/ShardsCalendarCard.ts
+++ b/packages/skyhelper/src/bot/utils/image-generators/ShardsCalendarCard.ts
@@ -388,7 +388,10 @@ export async function generateShardsCalendarCard(options: ShardsCalendarCardOpti
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.fillText(
-    `All timings shown after the daily reset (12 AM Los Angeles time; UTC ${now.toFormat("ZZ")})`,
+    `All timings shown after the daily reset (12 AM Los Angeles time; UTC ${
+      // construct an object for passed month and year, so DTS offset hare handled properly
+      DateTime.fromObject({ month, year }, { zone }).toFormat("ZZ")
+    })`,
     width / 2,
     titleY + px(100),
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 0.8.5
       discord-api-types:
         specifier: latest
-        version: 0.38.49
+        version: 0.38.53
       framer-motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -210,7 +210,7 @@ importers:
     dependencies:
       discord-api-types:
         specifier: latest
-        version: 0.38.49
+        version: 0.38.53
     devDependencies:
       '@types/luxon':
         specifier: ^3.6.2
@@ -256,7 +256,7 @@ importers:
         version: link:../utils
       discord-api-types:
         specifier: latest
-        version: 0.38.49
+        version: 0.38.53
       i18next:
         specifier: ^23.12.2
         version: 23.16.8
@@ -302,13 +302,13 @@ importers:
         version: 2.1.1
       '@discordjs/core':
         specifier: dev
-        version: 3.0.0-dev.1782606054-b9c59f784
+        version: 3.0.0-dev.1786233958-b1a77045f
       '@discordjs/rest':
         specifier: dev
-        version: 3.0.0-dev.1782606054-b9c59f784
+        version: 3.0.0-dev.1786233958-b1a77045f
       '@discordjs/ws':
         specifier: dev
-        version: 3.0.0-dev.1782606054-b9c59f784
+        version: 3.0.0-dev.1786233958-b1a77045f
       '@imnaiyar/framework':
         specifier: latest
         version: 1.2.3
@@ -362,7 +362,7 @@ importers:
         version: 1.0.9
       discord-api-types:
         specifier: latest
-        version: 0.38.49
+        version: 0.38.53
       express:
         specifier: ^4.22.0
         version: 4.22.0
@@ -372,6 +372,9 @@ importers:
       i18next-fs-backend:
         specifier: ^2.6.6
         version: 2.6.6
+      lru-cache:
+        specifier: ^11.5.2
+        version: 11.5.2
       luxon:
         specifier: ^3.5.0
         version: 3.6.1
@@ -429,7 +432,7 @@ importers:
         version: link:../constants
       discord-api-types:
         specifier: latest
-        version: 0.38.49
+        version: 0.38.53
       undici:
         specifier: ^8.5.0
         version: 8.5.0
@@ -593,33 +596,33 @@ packages:
     resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
     engines: {node: '>=18'}
 
-  '@discordjs/collection@3.0.0-dev.1782606054-b9c59f784':
-    resolution: {integrity: sha512-bo8SrlyoduQ9cmGKNeBfaj6u+9lGhcoI3EExIKvY17POFRHnf/OAp9Illd9NQjXSYUUiGQoIjpYt/8B8qbUE7w==}
-    engines: {node: '>=22.12.0'}
+  '@discordjs/collection@3.0.0-dev.1786233958-b1a77045f':
+    resolution: {integrity: sha512-EqUCrOFy+o+iOFiopjKAf/57OLPEpkLk3pmQaKn1yLMpSJk4f3oddMbLy6ioj0l6j1iMHrcXcSjAu3sde/WA5w==}
+    engines: {node: '>=24.17.0'}
 
-  '@discordjs/core@3.0.0-dev.1782606054-b9c59f784':
-    resolution: {integrity: sha512-yJUvl6i59LLVqa77ww7TicvK93KKNOZ7SkX7dxpXYyL8FJor+5YZu1tYngvZNOsPyT1oqYP6KHwvVX8pGBKCEg==}
-    engines: {node: '>=22.12.0'}
+  '@discordjs/core@3.0.0-dev.1786233958-b1a77045f':
+    resolution: {integrity: sha512-fUXyoc08+g9+2kIx9kIDpjEI0VuvLPCC8Qg/q3prnn8z1UMybEjNfMGrfrzFxrH/5MDtAsthyQUpb2wLnKeUWQ==}
+    engines: {node: '>=24.17.0'}
 
   '@discordjs/rest@2.4.3':
     resolution: {integrity: sha512-+SO4RKvWsM+y8uFHgYQrcTl/3+cY02uQOH7/7bKbVZsTfrfpoE62o5p+mmV+s7FVhTX82/kQUGGbu4YlV60RtA==}
     engines: {node: '>=18'}
 
-  '@discordjs/rest@3.0.0-dev.1782606054-b9c59f784':
-    resolution: {integrity: sha512-kjDnFWkmM0uu4nfbcSmctF6D4NuZONjMbNbyD8x2BmedPoxTe+yLyWIeaFBaEOyxthWgeYc0+jv2TFcI6LyDYw==}
-    engines: {node: '>=22.12.0'}
+  '@discordjs/rest@3.0.0-dev.1786233958-b1a77045f':
+    resolution: {integrity: sha512-ZjZtKjbM7UbL4HmwbeI3Iy3N9aK/H/dh0PgsUCo1nXunbeZ61DTJkXJXqP8L/QzO9P2T6MBzolnjSUQqX6rzew==}
+    engines: {node: '>=24.17.0'}
 
   '@discordjs/util@1.1.1':
     resolution: {integrity: sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==}
     engines: {node: '>=18'}
 
-  '@discordjs/util@2.0.0-dev.1782606054-b9c59f784':
-    resolution: {integrity: sha512-CFg+7turpClUbJwzPwjwwJWmIAgMyQ4CWk7rCQBO2hGZbCL5MYxKiPrCFGQMQqN5nWSuYVZdZCWaqTdmuRpb5g==}
-    engines: {node: '>=22.12.0'}
+  '@discordjs/util@2.0.0-dev.1786233958-b1a77045f':
+    resolution: {integrity: sha512-OLPn0UvvqQjMK8E1fkcEE2maf/pa5hO0RFx4jUJgf0/EXM7onIxNZ4laLfU3YhUFQ++1EnwrUXRTJ+QhvKi/mA==}
+    engines: {node: '>=24.17.0'}
 
-  '@discordjs/ws@3.0.0-dev.1782606054-b9c59f784':
-    resolution: {integrity: sha512-UKnqqO+KJomPv2/bxJJhSgWDkj7Lqan/QiEAyNaRrGTYeL620bb9aaok7syya6DDpRT1PKZPpOaGObjnnI2yvA==}
-    engines: {node: '>=22.12.0'}
+  '@discordjs/ws@3.0.0-dev.1786233958-b1a77045f':
+    resolution: {integrity: sha512-BZHIdtZ5g8ilj6rcd8HZZ0T4sKUgqqGHT4dH/rnzdgWZj13iI5hckNW5YCAuioktubaZXcE4NBMlkxMMVKF3dw==}
+    engines: {node: '>=24.17.0'}
 
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
@@ -3895,8 +3898,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  discord-api-types@0.38.49:
-    resolution: {integrity: sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==}
+  discord-api-types@0.38.53:
+    resolution: {integrity: sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -5159,6 +5162,10 @@ packages:
 
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lucide-react@0.540.0:
@@ -7216,16 +7223,16 @@ snapshots:
 
   '@discordjs/collection@2.1.1': {}
 
-  '@discordjs/collection@3.0.0-dev.1782606054-b9c59f784': {}
+  '@discordjs/collection@3.0.0-dev.1786233958-b1a77045f': {}
 
-  '@discordjs/core@3.0.0-dev.1782606054-b9c59f784':
+  '@discordjs/core@3.0.0-dev.1786233958-b1a77045f':
     dependencies:
-      '@discordjs/rest': 3.0.0-dev.1782606054-b9c59f784
-      '@discordjs/util': 2.0.0-dev.1782606054-b9c59f784
-      '@discordjs/ws': 3.0.0-dev.1782606054-b9c59f784
+      '@discordjs/rest': 3.0.0-dev.1786233958-b1a77045f
+      '@discordjs/util': 2.0.0-dev.1786233958-b1a77045f
+      '@discordjs/ws': 3.0.0-dev.1786233958-b1a77045f
       '@sapphire/snowflake': 3.5.5
       '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.49
+      discord-api-types: 0.38.53
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7237,19 +7244,19 @@ snapshots:
       '@sapphire/async-queue': 1.5.5
       '@sapphire/snowflake': 3.5.5
       '@vladfrangu/async_event_emitter': 2.4.6
-      discord-api-types: 0.38.49
+      discord-api-types: 0.38.53
       magic-bytes.js: 1.11.0
       tslib: 2.8.1
       undici: 6.21.1
 
-  '@discordjs/rest@3.0.0-dev.1782606054-b9c59f784':
+  '@discordjs/rest@3.0.0-dev.1786233958-b1a77045f':
     dependencies:
-      '@discordjs/collection': 3.0.0-dev.1782606054-b9c59f784
-      '@discordjs/util': 2.0.0-dev.1782606054-b9c59f784
+      '@discordjs/collection': 3.0.0-dev.1786233958-b1a77045f
+      '@discordjs/util': 2.0.0-dev.1786233958-b1a77045f
       '@sapphire/async-queue': 1.5.5
       '@sapphire/snowflake': 3.5.5
       '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.49
+      discord-api-types: 0.38.53
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
       undici: 7.24.6
@@ -7257,18 +7264,18 @@ snapshots:
 
   '@discordjs/util@1.1.1': {}
 
-  '@discordjs/util@2.0.0-dev.1782606054-b9c59f784':
+  '@discordjs/util@2.0.0-dev.1786233958-b1a77045f':
     dependencies:
-      discord-api-types: 0.38.49
+      discord-api-types: 0.38.53
 
-  '@discordjs/ws@3.0.0-dev.1782606054-b9c59f784':
+  '@discordjs/ws@3.0.0-dev.1786233958-b1a77045f':
     dependencies:
-      '@discordjs/collection': 3.0.0-dev.1782606054-b9c59f784
-      '@discordjs/util': 2.0.0-dev.1782606054-b9c59f784
+      '@discordjs/collection': 3.0.0-dev.1786233958-b1a77045f
+      '@discordjs/util': 2.0.0-dev.1786233958-b1a77045f
       '@sapphire/async-queue': 1.5.5
       '@types/ws': 8.18.1
       '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.49
+      discord-api-types: 0.38.53
       tslib: 2.8.1
       ws: 8.20.1
     transitivePeerDependencies:
@@ -9015,7 +9022,7 @@ snapshots:
 
   '@sapphire/discord-utilities@3.4.4':
     dependencies:
-      discord-api-types: 0.38.49
+      discord-api-types: 0.38.53
 
   '@sapphire/snowflake@3.5.5': {}
 
@@ -10516,7 +10523,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  discord-api-types@0.38.49: {}
+  discord-api-types@0.38.53: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -12212,6 +12219,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.1.0: {}
+
+  lru-cache@11.5.2: {}
 
   lucide-react@0.540.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
- **feat: add shard calendar generator**
- **feat: add generated shard calendar for shard-calendar command**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an infographic view for the shards calendar with a downloadable image.
  - Added a toggle between infographic and legacy calendar views.
  - Added localized labels and descriptions for both viewing modes.
  - Added configurable calendar previews for selected months and years.

- **Improvements**
  - Calendar interactions now provide loading feedback and smoother navigation.
  - Calendar images are reused efficiently for faster responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->